### PR TITLE
fix docs dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,12 @@ build:
 
 sphinx:
   configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs  # 如果你的项目有 docs 额外依赖
+    - requirements: docs/requirements.txt  # 或者直接安装 myst-parser
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+myst-parser
+sphinx-rtd-theme


### PR DESCRIPTION
This pull request updates the documentation build configuration to streamline the setup process and ensure necessary dependencies are installed. The changes primarily focus on the `readthedocs` configuration and documentation requirements.

### Updates to build configuration:

* [`.readthedocs.yaml`](diffhunk://#diff-03efc769b870804394632e45d7885272b44c16939517fb31c9d7c614d2ffae57R10-R18): Added a `python.install` section to specify installation methods and dependencies for building the documentation, including optional `docs` dependencies and a `requirements.txt` file.

### Updates to documentation dependencies:

* [`docs/requirements.txt`](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90R1-R3): Added `sphinx`, `myst-parser`, and `sphinx-rtd-theme` as required dependencies for building and rendering the documentation.