### PR TITLE
change docs theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,5 +23,5 @@ language = 'zh_CN'
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']


### PR DESCRIPTION
This pull request updates the Sphinx documentation theme for improved readability and consistency.

* [`docs/source/conf.py`](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L26-R26): Changed the `html_theme` from `'alabaster'` to `'sphinx_rtd_theme'` to switch to the Read the Docs theme.