### PR TITLE
docs(introduction): 添加项目封面图片

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -1,3 +1,5 @@
+![cover](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/img/repocover.png?raw=true)
+
 # 项目介绍
 
 ## SimpleLLMFunc 是什么?


### PR DESCRIPTION
This pull request adds a cover image to the project documentation to enhance its visual appeal.

Documentation update:

* [`docs/source/introduction.md`](diffhunk://#diff-6d8cd0012c7ea6ab802424951ac175faa22347e7ff7a2c149c08a8b8a2609570R1-R2): Added a cover image at the top of the introduction file using a link to the repository's `repocover.png`.