### PR TITLE
docs: add Mintlify site links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ### 📚 Complete Documentation
 
-> Read detailed documentation in Mintlify: Chinese docs at `/` and English docs at `/en` on the project documentation site.
+> Read detailed documentation: [Chinese Docs](https://simplellmfunc.cn/) | [English Docs](https://simplellmfunc.cn/en)
 -----
 
 ## 💡 Project Introduction
@@ -928,7 +928,7 @@ Welcome to submit Issues and Pull Requests!
 
 ## 📖 More Resources
 
-- 📚 Mintlify documentation site (Chinese `/`, English `/en`)
+- 📚 [Chinese Docs](https://simplellmfunc.cn/) | [English Docs](https://simplellmfunc.cn/en)
 - 🔄 [Changelog](CHANGELOG.md)
 - 🔗 [GitHub Repository](https://github.com/NiJingzhe/SimpleLLMFunc)
 - 🤖 [SimpleManus (Agent Framework)](https://github.com/NiJingzhe/SimpleManus)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -33,7 +33,7 @@
 
 ### 📚 完整文档
 
-阅读 Mintlify 文档站：中文位于 `/`，英文位于 `/en`
+阅读 Mintlify 文档站：[中文文档](https://simplellmfunc.cn/) | [English Docs](https://simplellmfunc.cn/en)
 
 > 💡 **多语言支持**: 本项目同时提供中文和英文文档，点击上方链接切换语言版本
 
@@ -932,7 +932,7 @@ python examples/tui_general_agent_example.py
 
 ## 📖 更多资源
 
-- 📚 Mintlify 文档站（中文 `/`，英文 `/en`）
+- 📚 [中文文档](https://simplellmfunc.cn/) | [English Docs](https://simplellmfunc.cn/en)
 - 🔄 [更新日志](CHANGELOG.md)
 - 🔗 [GitHub 仓库](https://github.com/NiJingzhe/SimpleLLMFunc)
 - 🤖 [SimpleManus (Agent 框架)](https://github.com/NiJingzhe/SimpleManus)


### PR DESCRIPTION
## Summary
- add explicit Mintlify documentation links to README and README_ZH
- point readers to `https://simplellmfunc.cn/` and `https://simplellmfunc.cn/en`