### PR TITLE
Add canonical multimodal chat input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ logs/
 **/log_indices/
 **/*.log
 examples/testlog/
+examples/_generated/
 
 examples/provider.json
 examples/**/provider.json
@@ -171,6 +172,7 @@ testlogs/
 coverage*
 htmlcov/
 .claude/
+.qoder/
 draft/
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log for SimpleLLMFunc
 
+## Unreleased
+
+### ✨ New Features
+
+1. **Multimodal input support**:
+   - `llm_function` now supports typed image input through explicit `ImgUrl` / `ImgPath` parameters and lists/unions containing those types.
+   - `llm_chat` now accepts `UserChatMessage` for OpenAI-compatible multimodal user messages containing text and `image_url` content parts.
+   - Added `UserChatMessage.multimodal(...)`, the canonical `UserChatMessage` helper for ergonomic chat message construction.
+
 ## 0.8.1 (2026-05-20) - Architecture Split: PyRepl, SelfRef, and Chat Decorator Internals
 
 ### 🔧 Improvements

--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ async def generate_chart(data: str, chart_type: str = "bar") -> ImgPath:
 
 Tools can be stacked with `@llm_function` on the same function.
 
+Tools can also return multiple images with optional text, for example `tuple[str, list[ImgPath | ImgUrl]]`. PyRepl's `execute_code` uses this path when code outputs images through `display(Image(...))` or an image-rich last expression.
+
 ### Multimodal Support
 
 ```python

--- a/README.md
+++ b/README.md
@@ -374,13 +374,13 @@ Tools can be stacked with `@llm_function` on the same function.
 ### Multimodal Support
 
 ```python
-from SimpleLLMFunc.type import ImgPath, ImgUrl, Text
+from SimpleLLMFunc.type import UserChatMessage, ImgPath, ImgUrl, Text
 
 @llm_function(llm_interface=llm)
 async def analyze_image(
     description: Text,        # Text description
-    web_image: ImgUrl,        # Web image URL
-    local_image: ImgPath      # Local image path
+    web_image: ImgUrl,        # Web image URL or data: URL
+    local_image: ImgPath      # Local image path, encoded as a data URL
 ) -> str:
     """Analyze images based on the description"""
     pass
@@ -390,7 +390,23 @@ result = await analyze_image(
     web_image=ImgUrl("https://example.com/image.jpg"),
     local_image=ImgPath("./reference.jpg")
 )
+
+@llm_chat(llm_interface=llm)
+async def vision_agent(message: UserChatMessage, history=None):
+    """Answer questions about the user's multimodal message."""
+    pass
+
+async for output in vision_agent(
+    UserChatMessage.multimodal(
+        "What is in this image?",
+        ImgUrl("https://example.com/cat.jpg", detail="high"),
+    ),
+    history=[],
+):
+    ...
 ```
+
+`llm_function` keeps the normal Python-function style: declare image parameters as `ImgUrl` / `ImgPath` / lists of those types. `llm_chat` accepts an explicit OpenAI-compatible `UserChatMessage`, so an Agent can receive text and image content in one user message.
 
 ### Tool-Call Limit Default
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -370,6 +370,8 @@ async def generate_chart(data: str, chart_type: str = "bar") -> ImgPath:
 
 `@tool` 可以与 `@llm_function` 叠加在同一个函数上。
 
+工具也可以返回多张图片并附带可选文本，例如 `tuple[str, list[ImgPath | ImgUrl]]`。当 PyRepl 的 `execute_code` 代码通过 `display(Image(...))` 或图片型最后表达式输出图片时，也会走这条多模态返回链路。
+
 ### 多模态支持
 
 ```python

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -373,13 +373,13 @@ async def generate_chart(data: str, chart_type: str = "bar") -> ImgPath:
 ### 多模态支持
 
 ```python
-from SimpleLLMFunc.type import ImgPath, ImgUrl, Text
+from SimpleLLMFunc.type import UserChatMessage, ImgPath, ImgUrl, Text
 
 @llm_function(llm_interface=llm)
 async def analyze_image(
     description: Text,        # 文本描述
-    web_image: ImgUrl,        # 网络图片 URL
-    local_image: ImgPath      # 本地图片路径
+    web_image: ImgUrl,        # 网络图片 URL 或 data: URL
+    local_image: ImgPath      # 本地图片路径，会编码为 data URL
 ) -> str:
     """根据描述分析图像"""
     pass
@@ -389,7 +389,23 @@ result = await analyze_image(
     web_image=ImgUrl("https://example.com/image.jpg"),
     local_image=ImgPath("./reference.jpg")
 )
+
+@llm_chat(llm_interface=llm)
+async def vision_agent(message: UserChatMessage, history=None):
+    """回答用户多模态消息中的问题。"""
+    pass
+
+async for output in vision_agent(
+    UserChatMessage.multimodal(
+        "这张图里有什么？",
+        ImgUrl("https://example.com/cat.jpg", detail="high"),
+    ),
+    history=[],
+):
+    ...
 ```
+
+`llm_function` 保持普通 Python 函数风格：通过显式声明 `ImgUrl` / `ImgPath` / 对应列表参数传入图片。`llm_chat` 则接受显式的 OpenAI-compatible `UserChatMessage`，让 Agent 可以在同一条 user message 中接收文本与图片内容。
 
 ### 工具调用上限默认值
 

--- a/SimpleLLMFunc/base/messages/multimodal.py
+++ b/SimpleLLMFunc/base/messages/multimodal.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, List, Optional
 
 from SimpleLLMFunc.logger import push_debug, push_error, push_warning
 from SimpleLLMFunc.logger.logger import get_location
+from SimpleLLMFunc.type.chat_input import (
+    UserChatMessage,
+    normalize_user_chat_content,
+)
 from SimpleLLMFunc.type.multimodal import ImgPath, ImgUrl, Text
 
 
@@ -14,7 +18,17 @@ def handle_union_type(value: Any, args: tuple, param_name: str) -> List[Dict[str
 
     content: List[Dict[str, Any]] = []
 
-    if isinstance(value, (Text, ImgUrl, ImgPath, str)):
+    if isinstance(
+        value,
+        (Text, ImgUrl, ImgPath, UserChatMessage, str),
+    ):
+        if isinstance(value, UserChatMessage):
+            normalized = normalize_user_chat_content(value)
+            return (
+                normalized
+                if isinstance(normalized, list)
+                else [create_text_content(normalized, param_name)]
+            )
         if isinstance(value, (Text, str)):
             content.append(create_text_content(value, param_name))
         elif isinstance(value, ImgUrl):
@@ -25,8 +39,19 @@ def handle_union_type(value: Any, args: tuple, param_name: str) -> List[Dict[str
 
     if isinstance(value, (list, tuple)):
         for i, item in enumerate(value):
-            if isinstance(item, (Text, ImgUrl, ImgPath, str)):
-                if isinstance(item, (Text, str)):
+            if isinstance(
+                item,
+                (Text, ImgUrl, ImgPath, UserChatMessage, str),
+            ):
+                if isinstance(item, UserChatMessage):
+                    normalized = normalize_user_chat_content(item)
+                    if isinstance(normalized, list):
+                        content.extend(normalized)
+                    else:
+                        content.append(
+                            create_text_content(normalized, f"{param_name}[{i}]")
+                        )
+                elif isinstance(item, (Text, str)):
                     content.append(create_text_content(item, f"{param_name}[{i}]"))
                 elif isinstance(item, ImgUrl):
                     content.append(create_image_url_content(item, f"{param_name}[{i}]"))
@@ -34,7 +59,10 @@ def handle_union_type(value: Any, args: tuple, param_name: str) -> List[Dict[str
                     content.append(create_image_path_content(item, f"{param_name}[{i}]"))
             else:
                 push_error(
-                    "多模态参数只能被标注为Optional[List[Text/ImgUrl/ImgPath]] 或 Optional[Text/ImgUrl/ImgPath] 或 List[Text/ImgUrl/ImgPath] 或 Text/ImgUrl/ImgPath",
+                    "Multimodal parameters must be annotated as "
+                    "Optional[List[Text/ImgUrl/ImgPath]], "
+                    "Optional[Text/ImgUrl/ImgPath], List[Text/ImgUrl/ImgPath], "
+                    "or Text/ImgUrl/ImgPath.",
                     location=get_location(),
                 )
                 content.append(create_text_content(item, f"{param_name}[{i}]"))
@@ -88,23 +116,31 @@ def parse_multimodal_parameter(
     if origin in (list, TypingList):
         if not isinstance(value, (list, tuple)):
             push_warning(
-                f"参数 {param_name} 应为列表类型，但获得 {type(value)}",
+                f"Parameter {param_name} should be a list, got {type(value)}.",
                 location=get_location(),
             )
             return [create_text_content(value, param_name)]
 
         if not args:
             push_error(
-                f"参数 {param_name} 的List类型缺少元素类型注解",
+                f"Parameter {param_name} list annotation is missing an element type.",
                 location=get_location(),
             )
             return [create_text_content(value, param_name)]
 
         element_type = args[0]
 
-        if element_type not in (Text, ImgUrl, ImgPath, str):
+        if element_type not in (
+            Text,
+            ImgUrl,
+            ImgPath,
+            UserChatMessage,
+            str,
+        ):
             push_error(
-                f"参数 {param_name} 的List类型必须直接包裹基础类型（Text, ImgUrl, ImgPath, str），但获得 {element_type}",
+                f"Parameter {param_name} list annotation must directly wrap "
+                "Text, ImgUrl, ImgPath, UserChatMessage, or str; "
+                f"got {element_type}.",
                 location=get_location(),
             )
             return [create_text_content(value, param_name)]
@@ -123,6 +159,13 @@ def parse_multimodal_parameter(
         return [create_image_url_content(value, param_name)]
     if annotation is ImgPath:
         return [create_image_path_content(value, param_name)]
+    if annotation is UserChatMessage:
+        normalized = normalize_user_chat_content(value)
+        return (
+            normalized
+            if isinstance(normalized, list)
+            else [create_text_content(normalized, param_name)]
+        )
 
     return [create_text_content(value, param_name)]
 

--- a/SimpleLLMFunc/base/tool_call/execution.py
+++ b/SimpleLLMFunc/base/tool_call/execution.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    cast,
     get_type_hints,
     get_origin,
     get_args,
@@ -42,6 +43,57 @@ class ExecutedToolCallResult:
     is_multimodal: bool = False
     success: bool = True
     error: Optional[Exception] = None
+
+
+def _is_image_payload(value: Any) -> bool:
+    return isinstance(value, (ImgPath, ImgUrl))
+
+
+def _is_image_payload_list(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(_is_image_payload(item) for item in value)
+    )
+
+
+def _build_image_content(image: ImgPath | ImgUrl) -> Dict[str, Any]:
+    if isinstance(image, ImgUrl):
+        return {
+            "type": "image_url",
+            "image_url": {
+                "url": image.url,
+                "detail": image.detail,
+            },
+        }
+
+    base64_img = image.to_base64()
+    mime_type = image.get_mime_type()
+    data_url = f"data:{mime_type};base64,{base64_img}"
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": data_url,
+            "detail": image.detail,
+        },
+    }
+
+
+def _build_multimodal_tool_message(
+    *,
+    text: str,
+    images: list[ImgPath | ImgUrl],
+) -> Dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": text,
+            },
+            *[_build_image_content(image) for image in images],
+        ],
+    }
 
 
 def _convert_tool_arguments(
@@ -306,8 +358,8 @@ async def execute_single_tool_call_result(
 
             if not is_valid_tool_result(tool_result):
                 push_warning(
-                    f"工具 '{tool_name}' 返回了不支持的格式: {type(tool_result)}。支持的返回格式包括: str, JSON可序列化对象, ImgPath, ImgUrl, Tuple[str, ImgPath], Tuple[str, ImgUrl]",
-                    f"Tool '{tool_name}' returned unsupported type {type(tool_result)}. Supported return formats: str, JSON-serializable objects, ImgPath, ImgUrl, Tuple[str, ImgPath], Tuple[str, ImgUrl]",
+                    f"工具 '{tool_name}' 返回了不支持的格式: {type(tool_result)}。支持的返回格式包括: str, JSON可序列化对象, ImgPath, ImgUrl, List[ImgPath | ImgUrl], Tuple[str, ImgPath], Tuple[str, ImgUrl], Tuple[str, List[ImgPath | ImgUrl]]",
+                    f"Tool '{tool_name}' returned unsupported type {type(tool_result)}. Supported return formats: str, JSON-serializable objects, ImgPath, ImgUrl, List[ImgPath | ImgUrl], Tuple[str, ImgPath], Tuple[str, ImgUrl], Tuple[str, List[ImgPath | ImgUrl]]",
                     location=get_location(),
                 )
                 tool_result_content_json: str = json.dumps(
@@ -328,24 +380,10 @@ async def execute_single_tool_call_result(
                 )
 
             if isinstance(tool_result, ImgUrl):
-                image_content = {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": tool_result.url,
-                        "detail": tool_result.detail,
-                    },
-                }
-
-                user_multimodal_message = {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"This is an image returned by tool '{tool_name}':",
-                        },
-                        image_content,
-                    ],
-                }
+                user_multimodal_message = _build_multimodal_tool_message(
+                    text=f"This is an image returned by tool '{tool_name}':",
+                    images=[tool_result],
+                )
                 messages_to_append.append(user_multimodal_message)
                 return ExecutedToolCallResult(
                     tool_call=tool_call,
@@ -357,28 +395,26 @@ async def execute_single_tool_call_result(
                 )
 
             if isinstance(tool_result, ImgPath):
-                base64_img = tool_result.to_base64()
-                mime_type = tool_result.get_mime_type()
-                data_url = f"data:{mime_type};base64,{base64_img}"
+                user_multimodal_message = _build_multimodal_tool_message(
+                    text=f"This is an image file returned by tool '{tool_name}':",
+                    images=[tool_result],
+                )
+                messages_to_append.append(user_multimodal_message)
+                return ExecutedToolCallResult(
+                    tool_call=tool_call,
+                    tool_call_id=str(tool_call_id or ""),
+                    tool_name=str(tool_name or ""),
+                    messages=messages_to_append,
+                    result=tool_result,
+                    is_multimodal=True,
+                )
 
-                image_content = {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": data_url,
-                        "detail": tool_result.detail,
-                    },
-                }
-
-                user_multimodal_message = {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"This is an image file returned by tool '{tool_name}':",
-                        },
-                        image_content,
-                    ],
-                }
+            if _is_image_payload_list(tool_result):
+                image_payloads = cast(list[ImgPath | ImgUrl], tool_result)
+                user_multimodal_message = _build_multimodal_tool_message(
+                    text=f"This is images returned by tool '{tool_name}':",
+                    images=image_payloads,
+                )
                 messages_to_append.append(user_multimodal_message)
                 return ExecutedToolCallResult(
                     tool_call=tool_call,
@@ -392,24 +428,10 @@ async def execute_single_tool_call_result(
             if isinstance(tool_result, tuple) and len(tool_result) == 2:
                 text_part, img_part = tool_result
                 if isinstance(text_part, str) and isinstance(img_part, ImgUrl):
-                    image_content = {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": img_part.url,
-                            "detail": img_part.detail,
-                        },
-                    }
-
-                    user_multimodal_message = {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": f"This is an image and description returned by tool '{tool_name}': {text_part}",
-                            },
-                            image_content,
-                        ],
-                    }
+                    user_multimodal_message = _build_multimodal_tool_message(
+                        text=f"This is an image and description returned by tool '{tool_name}': {text_part}",
+                        images=[img_part],
+                    )
                     messages_to_append.append(user_multimodal_message)
                     return ExecutedToolCallResult(
                         tool_call=tool_call,
@@ -421,28 +443,26 @@ async def execute_single_tool_call_result(
                     )
 
                 if isinstance(text_part, str) and isinstance(img_part, ImgPath):
-                    base64_img = img_part.to_base64()
-                    mime_type = img_part.get_mime_type()
-                    data_url = f"data:{mime_type};base64,{base64_img}"
+                    user_multimodal_message = _build_multimodal_tool_message(
+                        text=f"This is an image file and description returned by tool '{tool_name}': {text_part}",
+                        images=[img_part],
+                    )
+                    messages_to_append.append(user_multimodal_message)
+                    return ExecutedToolCallResult(
+                        tool_call=tool_call,
+                        tool_call_id=str(tool_call_id or ""),
+                        tool_name=str(tool_name or ""),
+                        messages=messages_to_append,
+                        result=tool_result,
+                        is_multimodal=True,
+                    )
 
-                    image_content = {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": data_url,
-                            "detail": img_part.detail,
-                        },
-                    }
-
-                    user_multimodal_message = {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": f"This is an image file and description returned by tool '{tool_name}': {text_part}",
-                            },
-                            image_content,
-                        ],
-                    }
+                if isinstance(text_part, str) and _is_image_payload_list(img_part):
+                    image_payloads = cast(list[ImgPath | ImgUrl], img_part)
+                    user_multimodal_message = _build_multimodal_tool_message(
+                        text=f"This is images and description returned by tool '{tool_name}': {text_part}",
+                        images=image_payloads,
+                    )
                     messages_to_append.append(user_multimodal_message)
                     return ExecutedToolCallResult(
                         tool_call=tool_call,

--- a/SimpleLLMFunc/base/tool_call/validation.py
+++ b/SimpleLLMFunc/base/tool_call/validation.py
@@ -8,6 +8,18 @@ from typing import Any
 from SimpleLLMFunc.type.multimodal import ImgPath, ImgUrl, Text
 
 
+def _is_image_payload(value: Any) -> bool:
+    return isinstance(value, (ImgPath, ImgUrl))
+
+
+def _is_image_payload_list(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(_is_image_payload(item) for item in value)
+    )
+
+
 def serialize_tool_output_for_langfuse(result: Any) -> Any:
     """序列化工具输出以便langfuse记录。
 
@@ -39,6 +51,14 @@ def serialize_tool_output_for_langfuse(result: Any) -> Any:
                 "text": text_part,
                 "image": serialize_tool_output_for_langfuse(img_part),
             }
+        if isinstance(text_part, str) and _is_image_payload_list(img_part):
+            return {
+                "type": "text_with_images",
+                "text": text_part,
+                "images": [
+                    serialize_tool_output_for_langfuse(item) for item in img_part
+                ],
+            }
 
     if isinstance(result, Text):
         return str(result.content)
@@ -57,12 +77,17 @@ def is_valid_tool_result(result: Any) -> bool:
     if isinstance(result, (ImgPath, ImgUrl)):
         return True
 
+    if _is_image_payload_list(result):
+        return True
+
     if isinstance(result, str):
         return True
 
     if isinstance(result, tuple) and len(result) == 2:
         text_part, img_part = result
         if isinstance(text_part, str) and isinstance(img_part, (ImgPath, ImgUrl)):
+            return True
+        if isinstance(text_part, str) and _is_image_payload_list(img_part):
             return True
         return False
 
@@ -71,4 +96,3 @@ def is_valid_tool_result(result: Any) -> bool:
         return True
     except (TypeError, ValueError):
         return False
-

--- a/SimpleLLMFunc/base/tool_scheduler.py
+++ b/SimpleLLMFunc/base/tool_scheduler.py
@@ -123,7 +123,11 @@ async def schedule_tool_batch(
 
             parsed_arguments_end = parse_tool_call_arguments(arguments_str, allow_closure=True)
             result_payload: ToolResult = ""
+            if execution_result.is_multimodal:
+                result_payload = cast(ToolResult, execution_result.result)
             for mutation in mutations:
+                if execution_result.is_multimodal:
+                    break
                 if isinstance(mutation, ToolResultMutation):
                     try:
                         result_payload = json.loads(mutation.content)

--- a/SimpleLLMFunc/base/type_resolve/multimodal.py
+++ b/SimpleLLMFunc/base/type_resolve/multimodal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from SimpleLLMFunc.type.chat_input import UserChatMessage
 from SimpleLLMFunc.type.multimodal import ImgPath, ImgUrl, Text
 
 
@@ -24,6 +25,8 @@ def has_multimodal_content(
             annotation = type_hints[param_name]
             if is_multimodal_type(param_value, annotation):
                 return True
+        elif isinstance(param_value, UserChatMessage):
+            return True
     return False
 
 
@@ -32,7 +35,7 @@ def is_multimodal_type(value: Any, annotation: Any) -> bool:
 
     from typing import List as TypingList, Union, get_args, get_origin
 
-    if isinstance(value, (Text, ImgUrl, ImgPath)):
+    if isinstance(value, (Text, ImgUrl, ImgPath, UserChatMessage)):
         return True
 
     origin = get_origin(annotation)
@@ -49,13 +52,16 @@ def is_multimodal_type(value: Any, annotation: Any) -> bool:
         if not args:
             return False
         element_type = args[0]
-        if element_type in (Text, ImgUrl, ImgPath):
+        if element_type in (Text, ImgUrl, ImgPath, UserChatMessage):
             return True
         if isinstance(value, (list, tuple)):
-            return any(isinstance(item, (Text, ImgUrl, ImgPath)) for item in value)
+            return any(
+                isinstance(item, (Text, ImgUrl, ImgPath, UserChatMessage))
+                for item in value
+            )
         return False
 
-    if annotation in (Text, ImgUrl, ImgPath):
+    if annotation in (Text, ImgUrl, ImgPath, UserChatMessage):
         return True
 
     return False

--- a/SimpleLLMFunc/builtin/pyrepl.py
+++ b/SimpleLLMFunc/builtin/pyrepl.py
@@ -147,7 +147,7 @@ class PyRepl(
         code: str,
         timeout_seconds: Optional[float] = None,
         event_emitter: Optional[ToolEventEmitter] = None,
-    ) -> str:
+    ) -> Any:
         return await execute_tool_adapter(
             self,
             code,

--- a/SimpleLLMFunc/builtin/pyrepl_execution.py
+++ b/SimpleLLMFunc/builtin/pyrepl_execution.py
@@ -83,6 +83,7 @@ class PyReplExecutionMixin:
             error_message: Optional[str] = None
             error_details: Optional[dict[str, Any]] = None
             return_value: Optional[str] = None
+            artifacts: List[dict[str, Any]] = []
 
             pending_input_requests: dict[str, queue.Queue[str]] = {}
             pending_input_waiters = 0
@@ -278,6 +279,11 @@ class PyReplExecutionMixin:
                                     else None
                                 )
                             )
+                            raw_artifacts = event.get("artifacts")
+                            if isinstance(raw_artifacts, list):
+                                artifacts = [
+                                    item for item in raw_artifacts if isinstance(item, dict)
+                                ]
                             break
 
                     now = time.monotonic()
@@ -364,6 +370,7 @@ class PyReplExecutionMixin:
                 "stdout": "".join(stdout_parts),
                 "stderr": "".join(stderr_parts),
                 "return_value": return_value,
+                "artifacts": artifacts,
                 "error": error_message,
                 "error_details": error_details,
                 "execution_time_ms": execution_time_ms,

--- a/SimpleLLMFunc/builtin/pyrepl_tools.py
+++ b/SimpleLLMFunc/builtin/pyrepl_tools.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from SimpleLLMFunc.hooks.event_emitter import ToolEventEmitter
 from SimpleLLMFunc.tool import TOO_LONG_TO_FILE_MAX_TOKENS, Tool
+from SimpleLLMFunc.type.multimodal import ImgPath, ImgUrl
 
 
 EXECUTE_TOOL_DESCRIPTION = (
@@ -71,7 +72,63 @@ def format_execute_tool_output(result: Dict[str, Any]) -> str:
         if isinstance(summary, str) and summary:
             lines.append(f"error_summary: {summary}")
 
+    artifacts = result.get("artifacts")
+    if isinstance(artifacts, list) and artifacts:
+        image_count = sum(
+            1
+            for artifact in artifacts
+            if isinstance(artifact, dict) and artifact.get("type") == "image"
+        )
+        if image_count:
+            suffix = "s" if image_count != 1 else ""
+            lines.append(f"image artifacts: {image_count} image artifact{suffix}")
+
     return "\n".join(lines)
+
+
+def _image_payload_from_artifact(artifact: Dict[str, Any]) -> ImgPath | ImgUrl | None:
+    if artifact.get("type") != "image":
+        return None
+
+    detail = artifact.get("detail")
+    if detail not in {"low", "high", "auto"}:
+        detail = "auto"
+
+    url = artifact.get("url")
+    if isinstance(url, str) and url:
+        try:
+            return ImgUrl(url, detail=detail)
+        except ValueError:
+            return None
+
+    path = artifact.get("path")
+    if isinstance(path, str) and path:
+        try:
+            return ImgPath(path, detail=detail)
+        except (FileNotFoundError, ValueError):
+            return None
+
+    return None
+
+
+def build_execute_tool_return(result: Dict[str, Any]) -> str | tuple[str, List[ImgPath | ImgUrl]]:
+    summary = format_execute_tool_output(result)
+    artifacts = result.get("artifacts")
+    if not isinstance(artifacts, list):
+        return summary
+
+    images: List[ImgPath | ImgUrl] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        image = _image_payload_from_artifact(artifact)
+        if image is not None:
+            images.append(image)
+
+    if not images:
+        return summary
+
+    return summary, images
 
 
 async def execute_tool_adapter(
@@ -79,13 +136,13 @@ async def execute_tool_adapter(
     code: str,
     timeout_seconds: Optional[float] = None,
     event_emitter: Optional[ToolEventEmitter] = None,
-) -> str:
+) -> str | tuple[str, List[ImgPath | ImgUrl]]:
     result = await repl.execute(
         code,
         timeout_seconds=timeout_seconds,
         event_emitter=event_emitter,
     )
-    return format_execute_tool_output(result)
+    return build_execute_tool_return(result)
 
 
 def create_pyrepl_tools(repl: Any) -> List[Tool]:
@@ -113,6 +170,7 @@ __all__ = [
     "RESET_TOOL_BEST_PRACTICES",
     "RESET_TOOL_DESCRIPTION",
     "create_pyrepl_tools",
+    "build_execute_tool_return",
     "execute_tool_adapter",
     "format_execute_tool_output",
 ]

--- a/SimpleLLMFunc/builtin/pyrepl_worker.py
+++ b/SimpleLLMFunc/builtin/pyrepl_worker.py
@@ -7,19 +7,23 @@ Parent/worker communication is message-based via multiprocessing queues.
 from __future__ import annotations
 
 import ast
+import base64
 import builtins
 import io
 import linecache
 import os
 import queue
 import sys
+import tempfile
 import time
 import traceback
 import uuid
 from typing import Any, Callable, Optional
 
+import IPython.display as ipython_display
 from IPython.core.interactiveshell import InteractiveShell
 from SimpleLLMFunc.runtime.worker_proxy import WorkerRuntimeProxy
+from SimpleLLMFunc.type.multimodal import ImgPath, ImgUrl
 
 
 EVENT_STDOUT = "stdout"
@@ -332,7 +336,179 @@ class _PyReplWorker:
         error_message = str(command.get("error_message", "primitive call failed"))
         raise self._make_remote_error(error_type, error_message)
 
-    def _execute_python_code(self, code: str, filename: str) -> Optional[str]:
+    @staticmethod
+    def _image_suffix_for_mime_type(mime_type: str) -> str:
+        return {
+            "image/png": ".png",
+            "image/jpeg": ".jpg",
+            "image/gif": ".gif",
+            "image/bmp": ".bmp",
+            "image/webp": ".webp",
+        }.get(mime_type, ".png")
+
+    @staticmethod
+    def _image_mime_type_for_repr_method(method_name: str) -> str:
+        return {
+            "_repr_png_": "image/png",
+            "_repr_jpeg_": "image/jpeg",
+            "_repr_svg_": "image/svg+xml",
+        }.get(method_name, "image/png")
+
+    @staticmethod
+    def _coerce_image_data_to_bytes(data: Any) -> Optional[bytes]:
+        if isinstance(data, bytes):
+            return data
+        if isinstance(data, bytearray):
+            return bytes(data)
+        if isinstance(data, str):
+            try:
+                return base64.b64decode(data, validate=True)
+            except Exception:
+                return data.encode("utf-8")
+        return None
+
+    def _write_image_artifact(
+        self,
+        *,
+        data: Any,
+        mime_type: str,
+        source: str,
+    ) -> Optional[dict[str, Any]]:
+        if mime_type == "image/svg+xml":
+            return None
+
+        image_bytes = self._coerce_image_data_to_bytes(data)
+        if image_bytes is None:
+            return None
+
+        suffix = self._image_suffix_for_mime_type(mime_type)
+        fd, path = tempfile.mkstemp(prefix="pyrepl_image_", suffix=suffix)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(image_bytes)
+
+        return {
+            "type": "image",
+            "source": source,
+            "path": path,
+            "mime_type": mime_type,
+            "detail": "auto",
+        }
+
+    def _artifact_from_mime_bundle(
+        self,
+        data: Any,
+        *,
+        source: str,
+    ) -> Optional[dict[str, Any]]:
+        if not isinstance(data, dict):
+            return None
+
+        for mime_type in ("image/png", "image/jpeg", "image/gif", "image/bmp", "image/webp"):
+            if mime_type not in data:
+                continue
+            return self._write_image_artifact(
+                data=data[mime_type],
+                mime_type=mime_type,
+                source=source,
+            )
+        return None
+
+    @staticmethod
+    def _artifact_from_img_url(value: ImgUrl) -> dict[str, Any]:
+        return {
+            "type": "image",
+            "source": "return_value",
+            "url": value.url,
+            "detail": value.detail,
+        }
+
+    @staticmethod
+    def _artifact_from_img_path(value: ImgPath) -> dict[str, Any]:
+        path = value.path.expanduser().resolve()
+        return {
+            "type": "image",
+            "source": "return_value",
+            "path": str(path),
+            "mime_type": value.get_mime_type(),
+            "detail": value.detail,
+        }
+
+    def _capture_result_artifact(
+        self,
+        result: Any,
+        artifacts: list[dict[str, Any]],
+    ) -> bool:
+        if isinstance(result, ImgUrl):
+            artifacts.append(self._artifact_from_img_url(result))
+            return True
+
+        if isinstance(result, ImgPath):
+            artifacts.append(self._artifact_from_img_path(result))
+            return True
+
+        for method_name in ("_repr_png_", "_repr_jpeg_"):
+            repr_method = getattr(result, method_name, None)
+            if not callable(repr_method):
+                continue
+            try:
+                image_data = repr_method()
+            except Exception:
+                continue
+            if image_data is None:
+                continue
+            artifact = self._write_image_artifact(
+                data=image_data,
+                mime_type=self._image_mime_type_for_repr_method(method_name),
+                source="return_value",
+            )
+            if artifact is not None:
+                artifacts.append(artifact)
+                return True
+
+        try:
+            data, _metadata = self._shell.display_formatter.format(result)
+        except Exception:
+            data = None
+        artifact = self._artifact_from_mime_bundle(data, source="return_value")
+        if artifact is not None:
+            artifacts.append(artifact)
+            return True
+
+        return False
+
+    def _execute_python_code(
+        self,
+        code: str,
+        filename: str,
+    ) -> tuple[Optional[str], list[dict[str, Any]]]:
+        artifacts: list[dict[str, Any]] = []
+        display_pub = self._shell.display_pub
+        old_publish = display_pub.publish
+        old_display = ipython_display.display
+        namespace_display_was_present = "display" in self._namespace
+        old_namespace_display = self._namespace.get("display")
+
+        def publish_hook(
+            data: Any,
+            metadata: Any = None,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            artifact = self._artifact_from_mime_bundle(data, source="display_data")
+            if artifact is not None:
+                artifacts.append(artifact)
+            return old_publish(data, metadata, *args, **kwargs)
+
+        def display_hook(*objs: Any, **kwargs: Any) -> None:
+            passthrough_objs = []
+            for obj in objs:
+                if self._capture_result_artifact(obj, artifacts):
+                    continue
+                passthrough_objs.append(obj)
+            if not passthrough_objs:
+                return None
+            return old_display(*passthrough_objs, **kwargs)
+
         transformed_code = self._shell.transform_cell(code)
         module_ast = ast.parse(transformed_code, filename=filename, mode="exec")
         body_nodes = list(module_ast.body)
@@ -341,28 +517,44 @@ class _PyReplWorker:
         if body_nodes and isinstance(body_nodes[-1], ast.Expr):
             last_expression = body_nodes.pop().value
 
-        if body_nodes:
-            module_for_exec = ast.Module(body=body_nodes, type_ignores=[])
-            ast.fix_missing_locations(module_for_exec)
-            exec(
-                compile(module_for_exec, filename, "exec"),
+        display_pub.publish = publish_hook
+        ipython_display.display = display_hook
+        if self._namespace.get("display") is old_display:
+            self._namespace["display"] = display_hook
+        try:
+            if body_nodes:
+                module_for_exec = ast.Module(body=body_nodes, type_ignores=[])
+                ast.fix_missing_locations(module_for_exec)
+                exec(
+                    compile(module_for_exec, filename, "exec"),
+                    self._namespace,
+                    self._namespace,
+                )
+
+            if last_expression is None:
+                return None, artifacts
+
+            expression_for_eval = ast.Expression(body=last_expression)
+            ast.fix_missing_locations(expression_for_eval)
+            result = eval(
+                compile(expression_for_eval, filename, "eval"),
                 self._namespace,
                 self._namespace,
             )
+            if result is None:
+                return None, artifacts
+            if self._capture_result_artifact(result, artifacts):
+                return None, artifacts
+            return repr(result), artifacts
+        finally:
+            display_pub.publish = old_publish
+            ipython_display.display = old_display
+            if self._namespace.get("display") is display_hook:
+                if namespace_display_was_present:
+                    self._namespace["display"] = old_namespace_display
+                else:
+                    self._namespace["display"] = old_display
 
-        if last_expression is None:
-            return None
-
-        expression_for_eval = ast.Expression(body=last_expression)
-        ast.fix_missing_locations(expression_for_eval)
-        result = eval(
-            compile(expression_for_eval, filename, "eval"),
-            self._namespace,
-            self._namespace,
-        )
-        if result is None:
-            return None
-        return repr(result)
 
     def _handle_execute(self, command: dict[str, Any]) -> None:
         exec_id = str(command.get("exec_id", ""))
@@ -386,6 +578,7 @@ class _PyReplWorker:
         error_message: Optional[str] = None
         error_details: Optional[dict[str, Any]] = None
         return_value: Optional[str] = None
+        artifacts: list[dict[str, Any]] = []
 
         old_stdout = sys.stdout
         old_stderr = sys.stderr
@@ -443,7 +636,10 @@ class _PyReplWorker:
         builtins.input = input_hook
 
         try:
-            return_value = self._execute_python_code(code=code, filename=filename)
+            return_value, artifacts = self._execute_python_code(
+                code=code,
+                filename=filename,
+            )
         except _InputRequestTimeoutError as exc:
             error_message = str(exc)
             on_stderr(error_message + "\n")
@@ -497,6 +693,7 @@ class _PyReplWorker:
             exec_id=exec_id,
             success=error_message is None,
             return_value=return_value,
+            artifacts=artifacts,
             error=error_message,
             error_details=error_details,
         )

--- a/SimpleLLMFunc/interface/openai_responses_compatible.py
+++ b/SimpleLLMFunc/interface/openai_responses_compatible.py
@@ -174,12 +174,11 @@ def _messages_to_response_input(
             continue
 
         if role == "user":
-            text = "" if content is None else str(content)
             input_items.append(
                 {
                     "type": "message",
                     "role": role,
-                    "content": [{"type": "input_text", "text": text}],
+                    "content": _user_content_to_response_content(content),
                 }
             )
             continue
@@ -229,6 +228,45 @@ def _messages_to_response_input(
                 }
             )
     return input_items
+
+
+def _user_content_to_response_content(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, list):
+        converted: list[dict[str, Any]] = []
+        for part in content:
+            if not isinstance(part, dict):
+                converted.append({"type": "input_text", "text": str(part)})
+                continue
+
+            part_type = part.get("type")
+            if part_type == "text":
+                converted.append(
+                    {"type": "input_text", "text": str(part.get("text", ""))}
+                )
+                continue
+
+            if part_type == "image_url":
+                image_url = part.get("image_url")
+                if isinstance(image_url, dict):
+                    url = image_url.get("url")
+                    if isinstance(url, str) and url:
+                        image_part: dict[str, Any] = {
+                            "type": "input_image",
+                            "image_url": url,
+                            "detail": "auto",
+                        }
+                        detail = image_url.get("detail")
+                        if detail in {"low", "high", "auto"}:
+                            image_part["detail"] = detail
+                        converted.append(image_part)
+                        continue
+
+            converted.append({"type": "input_text", "text": str(part)})
+
+        return converted or [{"type": "input_text", "text": ""}]
+
+    text = "" if content is None else str(content)
+    return [{"type": "input_text", "text": text}]
 
 
 def _extract_response_instructions(

--- a/SimpleLLMFunc/llm_decorator/chat_call_context.py
+++ b/SimpleLLMFunc/llm_decorator/chat_call_context.py
@@ -12,6 +12,7 @@ from SimpleLLMFunc.llm_decorator.chat_toolkit import (
 from SimpleLLMFunc.llm_decorator.chat_types import ToolkitList
 from SimpleLLMFunc.llm_decorator.signature import FunctionSignature, parse_function_signature
 from SimpleLLMFunc.runtime.selfref.state import SelfReference
+from SimpleLLMFunc.type.chat_input import normalize_user_chat_message
 
 
 @dataclass(frozen=True)
@@ -47,8 +48,17 @@ def build_chat_call_context(
         runtime_toolkit,
     )
 
+    task_arguments = dict(function_signature.bound_args.arguments)
+    if "message" in task_arguments:
+        try:
+            task_arguments["message"] = normalize_user_chat_message(
+                task_arguments["message"]
+            )
+        except ValueError:
+            pass
+
     user_task_prompt = json.dumps(
-        function_signature.bound_args.arguments,
+        task_arguments,
         default=str,
         ensure_ascii=False,
     )

--- a/SimpleLLMFunc/llm_decorator/llm_chat_decorator.py
+++ b/SimpleLLMFunc/llm_decorator/llm_chat_decorator.py
@@ -64,7 +64,12 @@ from SimpleLLMFunc.observability.langfuse_client import (
 )
 from SimpleLLMFunc.runtime.selfref.state import MemoryHistory, SelfReference
 from SimpleLLMFunc.tool import Tool
-from SimpleLLMFunc.type import HistoryList, MessageList, NormalizedMessageParam
+from SimpleLLMFunc.type import (
+    HistoryList,
+    MessageList,
+    NormalizedMessageParam,
+    UserChatMessage,
+)
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -182,20 +187,25 @@ class LLMChat:
             )
 
         message_annotation = message_param.annotation
+        allowed_message_annotations = {str, UserChatMessage}
+        if isinstance(message_annotation, str):
+            annotation_allowed = message_annotation in {
+                "str",
+                "UserChatMessage",
+            }
+        else:
+            annotation_allowed = message_annotation in allowed_message_annotations
+
         if (
             message_annotation is inspect.Signature.empty
             or message_annotation is None
-            or (
-                message_annotation is not str
-                and not (
-                    isinstance(message_annotation, str) and message_annotation == "str"
-                )
-            )
+            or not annotation_allowed
         ):
             raise TypeError(
                 "llm_chat(strict_signature=True) requires the second parameter to be "
-                "annotated as `str` for the user message, e.g. "
-                "`async def agent(history, message: str, ...)`."
+                "annotated as `str` or `UserChatMessage` for the user "
+                "message, e.g. "
+                "`async def agent(history, message: UserChatMessage, ...)`."
             )
 
         if message_param.name != "message":
@@ -209,7 +219,7 @@ class LLMChat:
                 continue
             raise TypeError(
                 "llm_chat(strict_signature=True) only allows an optional `_template_params` "
-                "parameter in addition to `(history, message: str)`. "
+                "parameter in addition to `(history, message)`. "
                 f"Unexpected parameter: {extra_param.name!r}."
             )
 

--- a/SimpleLLMFunc/llm_decorator/prompt_contract.py
+++ b/SimpleLLMFunc/llm_decorator/prompt_contract.py
@@ -21,6 +21,10 @@ from SimpleLLMFunc.logger.logger import get_location
 from SimpleLLMFunc.runtime.selfref.state import MemoryHistory
 from SimpleLLMFunc.tool import Tool
 from SimpleLLMFunc.type import HistoryList
+from SimpleLLMFunc.type.chat_input import (
+    UserChatMessage,
+    normalize_user_chat_message,
+)
 from SimpleLLMFunc.type.message import MessageList, MessageParam, NormalizedMessageList
 
 HISTORY_PARAM_NAMES: List[str] = ["history", "chat_history"]
@@ -268,12 +272,31 @@ def extract_conversation_history(
     return custom_history
 
 
+def _extract_explicit_chat_user_message(
+    arguments: Dict[str, Any],
+    exclude_params: List[str],
+) -> Optional[Dict[str, Any]]:
+    if "message" not in arguments or "message" in exclude_params:
+        return None
+
+    value = arguments["message"]
+    if isinstance(value, UserChatMessage):
+        return value.to_message()
+    if isinstance(value, dict) and value.get("role") == "user" and "content" in value:
+        return normalize_user_chat_message(value)
+    return None
+
+
 def build_chat_user_message_content(
     arguments: Dict[str, Any],
     type_hints: Dict[str, Any],
     has_multimodal: bool,
     exclude_params: List[str],
 ) -> Union[str, List[Dict[str, Any]]]:
+    explicit_message = _extract_explicit_chat_user_message(arguments, exclude_params)
+    if explicit_message is not None:
+        return cast(Union[str, List[Dict[str, Any]]], explicit_message["content"])
+
     if has_multimodal:
         return build_multimodal_content(
             arguments,
@@ -359,6 +382,11 @@ def build_chat_messages(
         type_hints,
         exclude_params=exclude_params,
     )
+    explicit_message = _extract_explicit_chat_user_message(arguments, exclude_params)
+    if explicit_message is not None:
+        messages.append(cast(MessageParam, explicit_message))
+        return messages
+
     user_message_content = build_chat_user_message_content(
         arguments,
         type_hints,
@@ -366,7 +394,9 @@ def build_chat_messages(
         exclude_params,
     )
     if user_message_content:
-        messages.append(cast(MessageParam, {"role": "user", "content": user_message_content}))
+        messages.append(
+            cast(MessageParam, {"role": "user", "content": user_message_content})
+        )
     return messages
 
 
@@ -378,6 +408,7 @@ __all__ = [
     "build_chat_messages",
     "build_chat_system_prompt",
     "build_chat_user_message_content",
+    "_extract_explicit_chat_user_message",
     "build_function_transcript_seed",
     "build_parameter_type_descriptions",
     "build_return_type_description",

--- a/SimpleLLMFunc/tool/tool.py
+++ b/SimpleLLMFunc/tool/tool.py
@@ -103,6 +103,59 @@ def _truncate_text_to_tokens(text: str, max_tokens: int) -> tuple[str, int]:
     return result_text, result_tokens
 
 
+def _truncate_tool_result_if_needed(tool_name: str, result: Any) -> Any:
+    if not isinstance(result, str):
+        return result
+
+    token_count = _estimate_token_count(result)
+
+    if token_count <= TOO_LONG_TO_FILE_MAX_TOKENS:
+        return result
+
+    temp_dir = tempfile.gettempdir()
+    temp_file = os.path.join(
+        temp_dir, f"tool_result_{tool_name}_{os.urandom(8).hex()}.txt"
+    )
+
+    try:
+        with open(temp_file, "w", encoding="utf-8") as f:
+            f.write(result)
+    except Exception as e:
+        push_error(f"Failed to save tool result to temporary file: {e}")
+        return result
+
+    truncated_text, _ = _truncate_text_to_tokens(
+        result,
+        TOO_LONG_TO_FILE_MAX_TOKENS,
+    )
+
+    reminder = (
+        "\n\n<system-reminder>\n"
+        "Tool output was too long, so this result has been truncated. "
+        f"The full result was saved to {temp_file}. "
+        "Use file-operation tools or PyRepl to read only the parts you need. "
+        "If you do not have a way to read files, warn the user and ask for help.\n"
+        "</system-reminder>"
+    )
+
+    return truncated_text + reminder
+
+
+def _truncate_multimodal_text_if_needed(tool_name: str, result: Any) -> Any:
+    if not (isinstance(result, tuple) and len(result) == 2):
+        return result
+    text_part, image_part = result
+    if not isinstance(text_part, str):
+        return result
+    if isinstance(image_part, (ImgPath, ImgUrl)) or (
+        isinstance(image_part, list)
+        and image_part
+        and all(isinstance(item, (ImgPath, ImgUrl)) for item in image_part)
+    ):
+        return (_truncate_tool_result_if_needed(tool_name, text_part), image_part)
+    return result
+
+
 class Parameter:
     """
     工具参数的简单包装类，仅用于存储信息，不作为主要API
@@ -292,41 +345,9 @@ class Tool(ABC):
             result = await self.func(*args, **kwargs)
 
             # 如果启用了 too_long_to_file 功能，检查结果是否需要截断
-            if self.too_long_to_file and isinstance(result, str):
-                token_count = _estimate_token_count(result)
-
-                if token_count > TOO_LONG_TO_FILE_MAX_TOKENS:
-                    # 将完整结果保存到临时文件
-                    temp_dir = tempfile.gettempdir()
-                    temp_file = os.path.join(
-                        temp_dir, f"tool_result_{self.name}_{os.urandom(8).hex()}.txt"
-                    )
-
-                    try:
-                        with open(temp_file, "w", encoding="utf-8") as f:
-                            f.write(result)
-                    except Exception as e:
-                        push_error(f"Failed to save tool result to temporary file: {e}")
-                        # 如果保存失败，直接返回原始结果
-                        return result
-
-                    # 截断文本到指定 token 数量
-                    truncated_text, _ = _truncate_text_to_tokens(
-                        result,
-                        TOO_LONG_TO_FILE_MAX_TOKENS,
-                    )
-
-                    # 添加提示信息
-                    reminder = (
-                        "\n\n<system-reminder>\n"
-                        "Tool output was too long, so this result has been truncated. "
-                        f"The full result was saved to {temp_file}. "
-                        "Use file-operation tools or PyRepl to read only the parts you need. "
-                        "If you do not have a way to read files, warn the user and ask for help.\n"
-                        "</system-reminder>"
-                    )
-
-                    return truncated_text + reminder
+            if self.too_long_to_file:
+                result = _truncate_tool_result_if_needed(self.name, result)
+                result = _truncate_multimodal_text_if_needed(self.name, result)
 
             return result
 
@@ -537,8 +558,10 @@ def tool(
     - **多模态返回**:
       - ImgPath: 返回本地图片路径，用于生成图表、处理后的图片等
       - ImgUrl: 返回网络图片URL，用于搜索到的图片、在线资源等
+      - List[ImgPath | ImgUrl]: 返回多张图片
       - Tuple[str, ImgPath]: 返回说明文本和图片的组合
       - Tuple[str, ImgUrl]: 返回说明文本和网络图片的组合
+      - Tuple[str, List[ImgPath | ImgUrl]]: 返回说明文本和多张图片的组合
     - **注意**: 返回值必须是可序列化的，不支持复杂对象
 
     ## 参数描述解析：

--- a/SimpleLLMFunc/type/__init__.py
+++ b/SimpleLLMFunc/type/__init__.py
@@ -2,6 +2,12 @@
 # 消息类型
 # ============================================================================
 from SimpleLLMFunc.type.message import (
+    ChatContentPart,
+    ChatImageDetail,
+    ChatImageUrl,
+    ChatImageUrlContentPart,
+    ChatMessageContent,
+    ChatTextContentPart,
     MessageList,
     MessageParam,
     NormalizedMessageList,
@@ -19,6 +25,14 @@ from SimpleLLMFunc.type.multimodal import (
     Text,
     MultimodalContent,
     MultimodalList,
+)
+from SimpleLLMFunc.type.chat_input import (
+    UserChatContent,
+    UserChatContentInput,
+    UserChatContentPart,
+    UserChatMessage,
+    normalize_user_chat_content,
+    normalize_user_chat_message,
 )
 
 # ============================================================================
@@ -71,6 +85,12 @@ __all__ = [
     "MessageList",
     "NormalizedMessageParam",
     "NormalizedMessageList",
+    "ChatContentPart",
+    "ChatImageDetail",
+    "ChatImageUrl",
+    "ChatImageUrlContentPart",
+    "ChatMessageContent",
+    "ChatTextContentPart",
     "ReasoningDetail",
     "ExtendedMessageParam",
     # 多模态类型
@@ -79,6 +99,12 @@ __all__ = [
     "ImgPath",
     "MultimodalContent",
     "MultimodalList",
+    "UserChatContent",
+    "UserChatContentInput",
+    "UserChatContentPart",
+    "UserChatMessage",
+    "normalize_user_chat_content",
+    "normalize_user_chat_message",
     # 工具调用类型
     "ToolCall",
     "ToolCallFunction",

--- a/SimpleLLMFunc/type/chat_input.py
+++ b/SimpleLLMFunc/type/chat_input.py
@@ -1,0 +1,136 @@
+"""Canonical user-message input object for ``llm_chat``.
+
+``UserChatMessage`` is the one supported multimodal input shape for chat
+agents.  It mirrors the OpenAI Chat Completions user-message schema while
+keeping construction Pythonic.  Future input modalities should extend this
+object instead of adding parallel chat input aliases.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, TypeAlias, Union, cast
+
+from SimpleLLMFunc.type.multimodal import ImgPath, ImgUrl
+
+UserChatContentPart: TypeAlias = Dict[str, Any]
+UserChatContent: TypeAlias = Union[str, List[UserChatContentPart]]
+UserChatContentInput: TypeAlias = Union[str, ImgUrl, ImgPath, UserChatContentPart]
+
+
+def _text_part(text: str) -> UserChatContentPart:
+    return {"type": "text", "text": text}
+
+
+def _image_url_part(image: ImgUrl) -> UserChatContentPart:
+    image_url_data = {"url": image.url}
+    if image.detail != "auto":
+        image_url_data["detail"] = image.detail
+    return {"type": "image_url", "image_url": image_url_data}
+
+
+def _image_path_part(image: ImgPath) -> UserChatContentPart:
+    data_url = f"data:{image.get_mime_type()};base64,{image.to_base64()}"
+    image_url_data = {"url": data_url}
+    if image.detail != "auto":
+        image_url_data["detail"] = image.detail
+    return {"type": "image_url", "image_url": image_url_data}
+
+
+def _normalize_content_part(part: UserChatContentInput) -> UserChatContentPart:
+    if isinstance(part, str):
+        return _text_part(part)
+    if isinstance(part, ImgUrl):
+        return _image_url_part(part)
+    if isinstance(part, ImgPath):
+        return _image_path_part(part)
+    if isinstance(part, dict):
+        normalized = dict(part)
+        part_type = normalized.get("type")
+        if part_type == "text" and isinstance(normalized.get("text"), str):
+            return normalized
+        if part_type == "image_url" and isinstance(normalized.get("image_url"), dict):
+            return normalized
+        raise ValueError(
+            "UserChatMessage content dict parts must be OpenAI-compatible "
+            "text or image_url parts"
+        )
+    raise ValueError(f"Unsupported user chat content part: {type(part).__name__}")
+
+
+def normalize_user_chat_content(value: Any) -> UserChatContent:
+    """Normalize ``UserChatMessage`` content to OAI-compatible user content."""
+
+    if isinstance(value, UserChatMessage):
+        return normalize_user_chat_content(value.content)
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, (ImgUrl, ImgPath)):
+        return [_normalize_content_part(cast(UserChatContentInput, value))]
+
+    if isinstance(value, dict):
+        if value.get("role") == "user" and "content" in value:
+            return normalize_user_chat_content(value.get("content"))
+        return [_normalize_content_part(cast(UserChatContentInput, value))]
+
+    if isinstance(value, tuple):
+        value = list(value)
+
+    if isinstance(value, list):
+        return [
+            _normalize_content_part(cast(UserChatContentInput, part))
+            for part in value
+        ]
+
+    raise ValueError(f"Unsupported user chat content: {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class UserChatMessage:
+    """OpenAI-compatible user message object for ``llm_chat``.
+
+    This is the canonical way to pass multimodal user input to chat agents.
+    Plain-text-only agents can still use ``message: str`` for backwards
+    compatibility, but multimodal input should go through this object.
+    """
+
+    content: UserChatContent
+    role: Literal["user"] = "user"
+
+    @classmethod
+    def text(cls, text: str) -> "UserChatMessage":
+        return cls(content=str(text))
+
+    @classmethod
+    def multimodal(cls, *parts: UserChatContentInput) -> "UserChatMessage":
+        return cls(content=normalize_user_chat_content(list(parts)))
+
+    def to_message(self) -> Dict[str, Any]:
+        return {"role": self.role, "content": normalize_user_chat_content(self.content)}
+
+
+def normalize_user_chat_message(value: Any) -> Dict[str, Any]:
+    """Normalize canonical chat input to ``{"role": "user", "content": ...}``."""
+
+    if isinstance(value, UserChatMessage):
+        return value.to_message()
+
+    if isinstance(value, dict) and value.get("role") == "user" and "content" in value:
+        return {**value, "content": normalize_user_chat_content(value.get("content"))}
+
+    raise ValueError(
+        "llm_chat multimodal input must be a UserChatMessage or an "
+        "OpenAI-compatible user message dict"
+    )
+
+
+__all__ = [
+    "UserChatContent",
+    "UserChatContentInput",
+    "UserChatContentPart",
+    "UserChatMessage",
+    "normalize_user_chat_content",
+    "normalize_user_chat_message",
+]

--- a/SimpleLLMFunc/type/hooks.py
+++ b/SimpleLLMFunc/type/hooks.py
@@ -143,8 +143,11 @@ ToolResult = Union[
     List[Any],                # 数组
     ImgPath,                  # 本地图片
     ImgUrl,                   # 图片 URL
+    List[ImgPath],            # 本地图片列表
+    List[ImgUrl],             # 图片 URL 列表
     Tuple[str, ImgPath],      # 文本 + 本地图片
     Tuple[str, ImgUrl],       # 文本 + 图片 URL
+    Tuple[str, List[Union[ImgPath, ImgUrl]]],  # 文本 + 多张图片
     Text,                     # 文本包装类
 ]
 """
@@ -153,7 +156,7 @@ ToolResult = Union[
 支持的类型：
 - 基本类型：str, dict, list
 - 多模态类型：ImgPath, ImgUrl, Text
-- 组合类型：(str, ImgPath), (str, ImgUrl)
+- 组合类型：(str, ImgPath), (str, ImgUrl), (str, list[ImgPath | ImgUrl])
 """
 
 # ============================================================================

--- a/SimpleLLMFunc/type/message.py
+++ b/SimpleLLMFunc/type/message.py
@@ -28,6 +28,27 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, NotRequired, TypeAlias, TypedDict
 
+ChatImageDetail: TypeAlias = Literal["low", "high", "auto"]
+
+
+class ChatTextContentPart(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+class ChatImageUrl(TypedDict, total=False):
+    url: str
+    detail: ChatImageDetail
+
+
+class ChatImageUrlContentPart(TypedDict):
+    type: Literal["image_url"]
+    image_url: ChatImageUrl
+
+
+ChatContentPart: TypeAlias = ChatTextContentPart | ChatImageUrlContentPart
+ChatMessageContent: TypeAlias = str | List[ChatContentPart]
+
 # Reasoning detail 的类型定义
 class ReasoningDetail(TypedDict):
     """推理细节的类型定义（用于 Google Gemini 等模型）"""
@@ -45,7 +66,7 @@ class ExtendedMessageParam(TypedDict, total=False):
     """
     # 基础字段
     role: str
-    content: str | List[Dict[str, Any]] | None
+    content: ChatMessageContent | None
     
     # OpenAI 标准字段
     refusal: NotRequired[str | None]

--- a/examples/pyrepl_seaborn_multimodal_images.py
+++ b/examples/pyrepl_seaborn_multimodal_images.py
@@ -1,0 +1,201 @@
+"""PyRepl multimodal image output example with seaborn.
+
+Run:
+    poetry run python examples/pyrepl_seaborn_multimodal_images.py
+    uv run python examples/pyrepl_seaborn_multimodal_images.py
+
+What this example demonstrates:
+1. Code executed inside PyRepl can generate multiple image artifacts.
+2. Direct ``repl.execute(...)`` exposes those artifacts in ``result["artifacts"]``.
+3. The ``execute_code`` tool converts image artifacts into a multimodal tool
+   return shaped as ``(summary: str, images: list[ImgPath | ImgUrl])``.
+
+This example does not require an LLM provider. It requires the repo's dev
+plotting dependencies: seaborn, pandas, and matplotlib.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+from SimpleLLMFunc.builtin import PyRepl
+from SimpleLLMFunc.type import ImgPath, ImgUrl
+
+
+WORKSPACE = Path(__file__).resolve().parent / "_generated" / "pyrepl_seaborn"
+REQUIRED_PLOT_PACKAGES = ("seaborn", "pandas", "matplotlib")
+
+
+PLOT_CODE = r'''
+from pathlib import Path
+
+from IPython.display import Image, display
+
+import math
+import random
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+output_dir = Path(".")
+
+rng = random.Random(2026)
+days = ["Thu", "Fri", "Sat", "Sun"]
+times = ["Lunch", "Dinner"]
+sexes = ["Female", "Male"]
+
+rows = []
+for index in range(180):
+    day = days[index % len(days)]
+    time = times[(index // 3) % len(times)]
+    sex = sexes[(index // 5) % len(sexes)]
+    party_size = 1 + (index % 6)
+    bill_base = 14 + days.index(day) * 3.2 + party_size * 2.6
+    total_bill = round(bill_base + rng.random() * 18, 2)
+    tip_rate = 0.13 + (0.03 if time == "Dinner" else 0.0) + rng.random() * 0.08
+    tip = round(total_bill * tip_rate + math.sin(index / 9) * 0.35, 2)
+    rows.append(
+        {
+            "total_bill": total_bill,
+            "tip": max(tip, 0.5),
+            "time": time,
+            "sex": sex,
+            "day": day,
+            "size": party_size,
+        }
+    )
+
+tips = pd.DataFrame(rows)
+print("Using seaborn with a local synthetic tips-like dataset")
+
+plot_specs = [
+    (
+        "tips_scatter.png",
+        lambda: sns.scatterplot(
+            data=tips,
+            x="total_bill",
+            y="tip",
+            hue="time",
+            style="sex",
+        ),
+        "Scatter: total bill vs tip",
+    ),
+    (
+        "tips_box.png",
+        lambda: sns.boxplot(data=tips, x="day", y="total_bill", hue="time"),
+        "Box plot: bill distribution by day",
+    ),
+    (
+        "tips_hist.png",
+        lambda: sns.histplot(data=tips, x="tip", hue="sex", kde=True),
+        "Histogram: tip distribution",
+    ),
+]
+
+saved_paths = []
+for filename, draw, title in plot_specs:
+    plt.figure(figsize=(7, 4))
+    draw()
+    plt.title(title)
+    plt.tight_layout()
+    path = output_dir / filename
+    plt.savefig(path, dpi=160)
+    plt.close()
+    saved_paths.append(path)
+
+print("Generated images:")
+for path in saved_paths:
+    print(path.resolve())
+
+for path in saved_paths:
+    display(Image(filename=str(path)))
+'''
+
+
+def ensure_plot_dependencies() -> bool:
+    missing = [
+        package
+        for package in REQUIRED_PLOT_PACKAGES
+        if importlib.util.find_spec(package) is None
+    ]
+    if not missing:
+        return True
+
+    missing_text = ", ".join(missing)
+    print(
+        "This example requires the dev plotting dependencies "
+        f"({missing_text} missing).\n"
+        "Install the repo dev dependencies and run again:\n"
+        "  poetry install --with dev\n"
+        "If you are maintaining the dependency list, add seaborn with:\n"
+        "  poetry add --group dev seaborn",
+        file=sys.stderr,
+    )
+    return False
+
+
+def describe_artifacts(artifacts: list[dict]) -> None:
+    print(f"artifact count: {len(artifacts)}")
+    for index, artifact in enumerate(artifacts, start=1):
+        print(
+            f"  {index}. type={artifact.get('type')} "
+            f"source={artifact.get('source')} "
+            f"mime={artifact.get('mime_type')} "
+            f"path={artifact.get('path') or artifact.get('url')}"
+        )
+
+
+def describe_tool_return(result: object) -> None:
+    if isinstance(result, tuple) and len(result) == 2:
+        summary, images = result
+        print("execute_code returned a multimodal tuple")
+        print("summary preview:")
+        print(textwrap.indent(str(summary).split("\n")[0], "  "))
+        if isinstance(images, list):
+            print(f"image payload count: {len(images)}")
+            for index, image in enumerate(images, start=1):
+                if isinstance(image, ImgPath):
+                    print(f"  {index}. ImgPath: {image.path}")
+                elif isinstance(image, ImgUrl):
+                    print(f"  {index}. ImgUrl: {image.url[:80]}")
+                else:
+                    print(f"  {index}. unexpected image payload: {type(image).__name__}")
+        return
+
+    print("execute_code returned a text-only result")
+    print(result)
+
+
+async def main() -> None:
+    WORKSPACE.mkdir(parents=True, exist_ok=True)
+    repl = PyRepl(working_directory=WORKSPACE)
+
+    print("=" * 80)
+    print("Direct PyRepl.execute(...) artifact capture")
+    print("=" * 80)
+    direct_result = await repl.execute(PLOT_CODE)
+    print(f"success: {direct_result['success']}")
+    print("stdout:")
+    print(textwrap.indent(direct_result["stdout"].strip(), "  "))
+    describe_artifacts(direct_result["artifacts"])
+
+    print("\n" + "=" * 80)
+    print("execute_code tool multimodal return")
+    print("=" * 80)
+    execute_tool = next(tool for tool in repl.toolset if tool.name == "execute_code")
+    tool_result = await execute_tool.run(PLOT_CODE)
+    describe_tool_return(tool_result)
+
+    print("\nGenerated files are under:")
+    print(f"  {WORKSPACE}")
+
+
+if __name__ == "__main__":
+    if not ensure_plot_dependencies():
+        raise SystemExit(1)
+    asyncio.run(main())

--- a/mintlify_docs/advanced/pyrepl.mdx
+++ b/mintlify_docs/advanced/pyrepl.mdx
@@ -15,6 +15,7 @@ In 0.8.1, `PyRepl` remains the public facade while its internals are split into 
 - **Isolated process** — Runs in a separate subprocess (multiprocessing spawn). Crashes don't kill the main process
 - **Runtime injection** — The `runtime` object is globally available. No imports needed
 - **Streaming output** — stdout/stderr stream in real-time via custom events
+- **Image artifacts** — images produced by `display(Image(...))` or image-rich last expressions are returned to the model as multimodal tool results
 - **Timeout protection** — Default 600s per execution. Configurable
 
 ## Setup
@@ -48,6 +49,40 @@ x
 ```
 
 Return value is the last expression's repr (like IPython).
+
+### Image Output
+
+When executed code produces image output, `execute_code` returns a multimodal tool result instead of flattening the image to text. The model receives the normal execution summary plus the image content.
+
+Supported patterns include explicit display calls:
+
+```python
+from IPython.display import Image, display
+
+display(Image(filename="chart.png"))
+```
+
+And image-rich last expressions:
+
+```python
+from IPython.display import Image
+
+Image(filename="chart.png")
+```
+
+For generated plots, saving the figure and returning an image payload is the clearest pattern:
+
+```python
+import matplotlib.pyplot as plt
+from SimpleLLMFunc.type import ImgPath
+
+plt.plot([1, 2, 3])
+path = "chart.png"
+plt.savefig(path)
+ImgPath(path)
+```
+
+Direct `PyRepl.execute(...)` calls expose captured images in the returned `artifacts` list. The `execute_code` tool converts those artifacts into `ImgPath` / `ImgUrl` multimodal returns for the agent loop.
 
 ### reset_repl
 

--- a/mintlify_docs/api/builtins.mdx
+++ b/mintlify_docs/api/builtins.mdx
@@ -130,10 +130,13 @@ Returns:
     "stdout": str,          # Captured stdout
     "stderr": str,          # Captured stderr
     "return_value": str,    # Repr of last expression (or None)
+    "artifacts": list,      # Captured image artifacts for direct PyRepl.execute calls
     "error": str | None,    # Error message if failed
     "execution_time_ms": float,
 }
 ```
+
+When used through the agent toolset, `execute_code` returns a natural-language summary. If code outputs images through `display(Image(...))`, an image-rich last expression, or `ImgPath(...)` / `ImgUrl(...)`, the tool result becomes multimodal so the model can inspect the image.
 
 #### reset_repl
 

--- a/mintlify_docs/api/decorators.mdx
+++ b/mintlify_docs/api/decorators.mdx
@@ -22,6 +22,8 @@ from SimpleLLMFunc import llm_function
 
 Transforms an async function into an `LLMFunction` callable instance. `await fn(...)` returns the parsed typed result; `fn.stream(...)` yields `ReactOutput`.
 
+For multimodal input, keep the normal Python-function style: explicitly type image parameters as `ImgUrl`, `ImgPath`, or lists/unions containing those types. `ImgUrl` accepts `http(s)` URLs and `data:` URLs; `ImgPath` is encoded as an image data URL at the provider boundary.
+
 ### Parameters
 
 | Parameter | Type | Default | Description |
@@ -83,6 +85,8 @@ from SimpleLLMFunc import llm_chat
 
 Creates an `LLMChat` callable instance. Calling it yields `AsyncGenerator[ReactOutput, None]` and gives SelfRef a stable agent identity.
 
+For multimodal chat input, prefer a single explicit `message: UserChatMessage` argument. `UserChatMessage` is OpenAI Chat Completions-compatible and can contain text and `image_url` content parts.
+
 ### Parameters
 
 | Parameter | Type | Default | Description |
@@ -129,6 +133,27 @@ async for output in agent("What is SimpleLLMFunc?", history):
     if is_response_yield(output):
         print(output.response)
         history = output.messages
+```
+
+### Multimodal Chat Example
+
+```python
+from SimpleLLMFunc import llm_chat
+from SimpleLLMFunc.type import UserChatMessage, ImgUrl
+
+@llm_chat(llm_interface=llm)
+async def vision_agent(message: UserChatMessage, history: list | None = None):
+    """Answer questions about user-provided images."""
+    pass
+
+async for output in vision_agent(
+    UserChatMessage.multimodal(
+        "What is in this image?",
+        ImgUrl("https://example.com/cat.jpg", detail="high"),
+    ),
+    history=[],
+):
+    ...
 ```
 
 ---

--- a/mintlify_docs/cookbook/examples.mdx
+++ b/mintlify_docs/cookbook/examples.mdx
@@ -35,6 +35,7 @@ All examples are in the [`examples/`](https://github.com/NiJingzhe/SimpleLLMFunc
 | Example | What It Shows |
 |---------|--------------|
 | `pyrepl_example.py` | Persistent REPL: variables, streaming, reset |
+| `pyrepl_seaborn_multimodal_images.py` | PyRepl image artifact capture and multimodal tool return with multiple seaborn plots |
 | `selfref_example.py` | `runtime.selfref.context.*` primitives |
 
 ## Full Agent

--- a/mintlify_docs/guide/llm-chat.mdx
+++ b/mintlify_docs/guide/llm-chat.mdx
@@ -65,6 +65,32 @@ async for output in assistant("Tell me about Python", history):
 
 With `stream=False`, the model response arrives as a single `ResponseYield`.
 
+## Multimodal User Messages
+
+For multimodal chat input, use exactly one canonical user-message object: `UserChatMessage`. This keeps `@llm_chat` as an Agent abstraction over one user turn and avoids multiple competing image-parameter styles.
+
+```python
+from SimpleLLMFunc import llm_chat
+from SimpleLLMFunc.type import ImgPath, ImgUrl, UserChatMessage
+
+@llm_chat(llm_interface=llm, stream=True)
+async def vision_agent(message: UserChatMessage, history: list | None = None):
+    """Answer questions about user-provided images."""
+    pass
+
+async for output in vision_agent(
+    UserChatMessage.multimodal(
+        "Compare these images and list visible differences.",
+        ImgUrl("https://example.com/reference.jpg", detail="high"),
+        ImgPath("./candidate.png", detail="high"),
+    ),
+    history=[],
+):
+    ...
+```
+
+`UserChatMessage.multimodal(...)` accepts text plus any number of `ImgUrl` / `ImgPath` values. It normalizes them to an OpenAI-compatible user message with `text` and `image_url` content parts. Future modalities should extend `UserChatMessage`, not introduce another chat input convention.
+
 ## Tools
 
 ```python

--- a/mintlify_docs/guide/llm-function.mdx
+++ b/mintlify_docs/guide/llm-function.mdx
@@ -108,6 +108,32 @@ result = await answer(
 )
 ```
 
+## Multimodal Image Parameters
+
+`@llm_function` keeps the normal Python-function shape for image input: declare explicit image parameters in the function signature.
+
+```python
+from SimpleLLMFunc import llm_function
+from SimpleLLMFunc.type import ImgPath, ImgUrl, Text
+
+@llm_function(llm_interface=llm)
+async def compare_images(
+    instruction: Text,
+    reference: ImgUrl,
+    candidate: ImgPath,
+) -> str:
+    """Compare the two images according to the instruction."""
+    pass
+
+result = await compare_images(
+    Text("Explain the visual differences."),
+    ImgUrl("https://example.com/reference.jpg", detail="high"),
+    ImgPath("./candidate.png", detail="high"),
+)
+```
+
+Use `ImgUrl` for web URLs or `data:` URLs. Use `ImgPath` for local files; the framework encodes the image as a data URL before sending it to the model. Multiple images should be expressed as explicit parameters or typed lists such as `list[ImgUrl]` / `list[ImgPath]`.
+
 ## With Tools
 
 `@llm_function` can use tools via a ReAct loop:

--- a/mintlify_docs/guide/tools.mdx
+++ b/mintlify_docs/guide/tools.mdx
@@ -147,6 +147,15 @@ async def analyze_image(image_path: str) -> tuple[str, ImgPath]:
     return description, annotated
 ```
 
+For multiple images, return a non-empty list or pair text with a list:
+
+```python
+@tool
+async def compare_images(left: str, right: str) -> tuple[str, list[ImgPath | ImgUrl]]:
+    """Return a comparison note and both images."""
+    return "Compare these two images", [ImgPath(left), ImgPath(right)]
+```
+
 ## Long Output Handling
 
 For tools that produce very long output:

--- a/mintlify_docs/zh/advanced/pyrepl.mdx
+++ b/mintlify_docs/zh/advanced/pyrepl.mdx
@@ -13,6 +13,7 @@ PyRepl 是一个运行在子进程中的持久化 IPython REPL。它为模型提
 - **进程隔离** —— 运行在独立子进程中（multiprocessing spawn）。崩溃不会影响主进程
 - **运行时注入** —— `runtime` 对象全局可用，无需导入
 - **流式输出** —— stdout/stderr 通过自定义事件实时流式传输
+- **图片产物** —— `display(Image(...))` 或最后表达式产生的图片会作为多模态工具结果返回给模型
 - **超时保护** —— 每次执行默认 600 秒超时，可配置
 
 ## 设置
@@ -46,6 +47,40 @@ x
 ```
 
 返回值是最后一个表达式的 repr（与 IPython 行为一致）。
+
+### 图片输出
+
+当执行代码产生图片输出时，`execute_code` 会返回多模态工具结果，而不是把图片压平成文本。模型会同时收到正常的执行摘要和图片内容。
+
+支持显式 display 调用：
+
+```python
+from IPython.display import Image, display
+
+display(Image(filename="chart.png"))
+```
+
+也支持最后表达式为可渲染图片对象：
+
+```python
+from IPython.display import Image
+
+Image(filename="chart.png")
+```
+
+对于生成图表，最清晰的模式是保存图片并返回图片 payload：
+
+```python
+import matplotlib.pyplot as plt
+from SimpleLLMFunc.type import ImgPath
+
+plt.plot([1, 2, 3])
+path = "chart.png"
+plt.savefig(path)
+ImgPath(path)
+```
+
+直接调用 `PyRepl.execute(...)` 时，捕获到的图片会出现在返回值的 `artifacts` 列表里。作为 agent 工具使用的 `execute_code` 会把这些 artifact 转成 `ImgPath` / `ImgUrl` 多模态返回。
 
 ### reset_repl
 

--- a/mintlify_docs/zh/api/builtins.mdx
+++ b/mintlify_docs/zh/api/builtins.mdx
@@ -130,10 +130,13 @@ async def execute_code(code: str, event_emitter=None) -> dict:
     "stdout": str,          # Captured stdout
     "stderr": str,          # Captured stderr
     "return_value": str,    # Repr of last expression (or None)
+    "artifacts": list,      # 直接调用 PyRepl.execute 时捕获到的图片产物
     "error": str | None,    # Error message if failed
     "execution_time_ms": float,
 }
 ```
+
+通过 agent toolset 使用时，`execute_code` 返回自然语言摘要。如果代码通过 `display(Image(...))`、图片型最后表达式，或 `ImgPath(...)` / `ImgUrl(...)` 输出图片，工具结果会变成多模态结果，模型可以直接查看图片。
 
 #### reset_repl
 

--- a/mintlify_docs/zh/api/decorators.mdx
+++ b/mintlify_docs/zh/api/decorators.mdx
@@ -22,6 +22,8 @@ from SimpleLLMFunc import llm_function
 
 将一个异步函数转换为 `LLMFunction` callable instance。`await fn(...)` 返回解析后的类型化结果；`fn.stream(...)` 产出 `ReactOutput`。
 
+对于多模态输入，`llm_function` 保持普通 Python 函数风格：显式把图片参数标注为 `ImgUrl`、`ImgPath`，或包含这些类型的列表/Union。`ImgUrl` 支持 `http(s)` URL 与 `data:` URL；`ImgPath` 会在 provider 边界编码为图片 data URL。
+
 ### 参数
 
 | 参数 | 类型 | 默认值 | 描述 |
@@ -83,6 +85,8 @@ from SimpleLLMFunc import llm_chat
 
 创建一个 `LLMChat` callable instance。调用它会产出 `AsyncGenerator[ReactOutput, None]`，并为 SelfRef 提供稳定的 agent identity。
 
+对于多模态 chat 输入，推荐使用单个显式的 `message: UserChatMessage` 参数。`UserChatMessage` 兼容 OpenAI Chat Completions user message，可以包含 text 与 `image_url` content parts。
+
 ### 参数
 
 | 参数 | 类型 | 默认值 | 描述 |
@@ -129,6 +133,27 @@ async for output in agent("What is SimpleLLMFunc?", history):
     if is_response_yield(output):
         print(output.response)
         history = output.messages
+```
+
+### 多模态 Chat 示例
+
+```python
+from SimpleLLMFunc import llm_chat
+from SimpleLLMFunc.type import UserChatMessage, ImgUrl
+
+@llm_chat(llm_interface=llm)
+async def vision_agent(message: UserChatMessage, history: list | None = None):
+    """回答用户图片相关的问题。"""
+    pass
+
+async for output in vision_agent(
+    UserChatMessage.multimodal(
+        "这张图里有什么？",
+        ImgUrl("https://example.com/cat.jpg", detail="high"),
+    ),
+    history=[],
+):
+    ...
 ```
 
 ---

--- a/mintlify_docs/zh/cookbook/examples.mdx
+++ b/mintlify_docs/zh/cookbook/examples.mdx
@@ -35,6 +35,7 @@ description: SimpleLLMFunc 仓库中分类的可运行示例
 | 示例 | 展示内容 |
 |---------|--------------|
 | `pyrepl_example.py` | 持久化 REPL：变量、流式输出、重置 |
+| `pyrepl_seaborn_multimodal_images.py` | PyRepl 图片产物捕获，以及多张 seaborn 图的多模态工具返回 |
 | `selfref_example.py` | `runtime.selfref.context.*` 原语 |
 
 ## 完整 Agent

--- a/mintlify_docs/zh/guide/llm-chat.mdx
+++ b/mintlify_docs/zh/guide/llm-chat.mdx
@@ -65,6 +65,32 @@ async for output in assistant("Tell me about Python", history):
 
 设置 `stream=False` 时，模型响应会作为单个 `ResponseYield` 一次性返回。
 
+## 多模态用户消息
+
+对于多模态 chat 输入，只使用一个 canonical user-message 对象：`UserChatMessage`。这样 `@llm_chat` 仍然是“一个用户回合”的 Agent 抽象，不会出现多套图片参数风格。
+
+```python
+from SimpleLLMFunc import llm_chat
+from SimpleLLMFunc.type import ImgPath, ImgUrl, UserChatMessage
+
+@llm_chat(llm_interface=llm, stream=True)
+async def vision_agent(message: UserChatMessage, history: list | None = None):
+    """Answer questions about user-provided images."""
+    pass
+
+async for output in vision_agent(
+    UserChatMessage.multimodal(
+        "Compare these images and list visible differences.",
+        ImgUrl("https://example.com/reference.jpg", detail="high"),
+        ImgPath("./candidate.png", detail="high"),
+    ),
+    history=[],
+):
+    ...
+```
+
+`UserChatMessage.multimodal(...)` 接受文本以及任意数量的 `ImgUrl` / `ImgPath`。它会归一化为 OpenAI-compatible user message，包含 `text` 与 `image_url` content parts。未来新增输入模态时也应扩展 `UserChatMessage`，而不是新增另一套 chat 输入约定。
+
 ## 工具
 
 ```python

--- a/mintlify_docs/zh/guide/llm-function.mdx
+++ b/mintlify_docs/zh/guide/llm-function.mdx
@@ -108,6 +108,32 @@ result = await answer(
 )
 ```
 
+## 多模态图片参数
+
+`@llm_function` 对图片输入保持普通 Python 函数形态：在函数签名里显式声明图片参数。
+
+```python
+from SimpleLLMFunc import llm_function
+from SimpleLLMFunc.type import ImgPath, ImgUrl, Text
+
+@llm_function(llm_interface=llm)
+async def compare_images(
+    instruction: Text,
+    reference: ImgUrl,
+    candidate: ImgPath,
+) -> str:
+    """Compare the two images according to the instruction."""
+    pass
+
+result = await compare_images(
+    Text("Explain the visual differences."),
+    ImgUrl("https://example.com/reference.jpg", detail="high"),
+    ImgPath("./candidate.png", detail="high"),
+)
+```
+
+`ImgUrl` 用于网络 URL 或 `data:` URL。`ImgPath` 用于本地文件，框架会在发送给模型前编码为 data URL。多张图片应表达为显式参数，或 `list[ImgUrl]` / `list[ImgPath]` 这样的类型化列表。
+
 ## 搭配工具使用
 
 `@llm_function` 可以通过 ReAct 循环使用工具：

--- a/mintlify_docs/zh/guide/tools.mdx
+++ b/mintlify_docs/zh/guide/tools.mdx
@@ -147,6 +147,15 @@ async def analyze_image(image_path: str) -> tuple[str, ImgPath]:
     return description, annotated
 ```
 
+对于多张图片，可以返回非空列表，或把文本与图片列表组合返回：
+
+```python
+@tool
+async def compare_images(left: str, right: str) -> tuple[str, list[ImgPath | ImgUrl]]:
+    """Return a comparison note and both images."""
+    return "Compare these two images", [ImgPath(left), ImgPath(right)]
+```
+
 ## 长输出处理
 
 对于产生超长输出的工具：

--- a/poetry.lock
+++ b/poetry.lock
@@ -252,6 +252,114 @@ files = [
 markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "contourpy"
+version = "1.3.3"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1"},
+    {file = "contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a"},
+    {file = "contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db"},
+    {file = "contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620"},
+    {file = "contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f"},
+    {file = "contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff"},
+    {file = "contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42"},
+    {file = "contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470"},
+    {file = "contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb"},
+    {file = "contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea"},
+    {file = "contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1"},
+    {file = "contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7"},
+    {file = "contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411"},
+    {file = "contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69"},
+    {file = "contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b"},
+    {file = "contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc"},
+    {file = "contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5"},
+    {file = "contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67"},
+    {file = "contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9"},
+    {file = "contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659"},
+    {file = "contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7"},
+    {file = "contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d"},
+    {file = "contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263"},
+    {file = "contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9"},
+    {file = "contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d"},
+    {file = "contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99"},
+    {file = "contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b"},
+    {file = "contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a"},
+    {file = "contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8"},
+    {file = "contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301"},
+    {file = "contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a"},
+    {file = "contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36"},
+    {file = "contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3"},
+    {file = "contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b"},
+    {file = "contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36"},
+    {file = "contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d"},
+    {file = "contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd"},
+    {file = "contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339"},
+    {file = "contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772"},
+    {file = "contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f"},
+    {file = "contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0"},
+    {file = "contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4"},
+    {file = "contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc"},
+    {file = "contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989"},
+    {file = "contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77"},
+    {file = "contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880"},
+]
+
+[package.dependencies]
+numpy = ">=1.25"
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
+mypy = ["bokeh", "contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.17.0)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+description = "Composable style cycles"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
+    {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
+]
+
+[package.extras]
+docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
+tests = ["pytest", "pytest-cov", "pytest-xdist"]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 description = "Decorators for Humans"
@@ -301,6 +409,79 @@ files = [
 
 [package.extras]
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+description = "Tools to manipulate font files"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3297a6a4059b4acc3a1e9a8b04741f240a80044eef08ebd32e8b5bcdddce75b"},
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b1cd75a03ad8cb5bc40c90bfde68c0c47de423aa19e5c0f362b43520645eea94"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0425b277a59cff3d80ca42162a8de360f318438a2ac83570842a678d826d579"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7e5c9973aa04c95650c96e5f5ad865fbf42d62079163ecfab1e01cbc2504c22"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cb014d58140a38135f16064c74c652ed57aa0b75cbf8bb59cac821f7edb5334e"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:032038247a96c1690f9f31e377c389383c902531b085aa4e4dabd6f57f870e69"},
+    {file = "fonttools-4.63.0-cp310-cp310-win32.whl", hash = "sha256:a8b33a82979e0a6a34ff435cc81317be1f95ec1ebb7a3a2d1c8a6a54f02ae44e"},
+    {file = "fonttools-4.63.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c18358a155d75034911c5ee397a5b44cd19dd325dbb8b35fb60bf421d6a72ac"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007"},
+    {file = "fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb"},
+    {file = "fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78"},
+    {file = "fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263"},
+    {file = "fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27"},
+    {file = "fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380"},
+    {file = "fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4"},
+    {file = "fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616"},
+    {file = "fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419"},
+    {file = "fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d"},
+    {file = "fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0"},
+]
+
+[package.extras]
+all = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "lxml (>=4.0)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\"", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.45.0)", "unicodedata2 (>=17.0.0) ; python_version <= \"3.14\"", "xattr ; sys_platform == \"darwin\"", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\""]
+lxml = ["lxml (>=4.0)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.45.0)"]
+symfont = ["sympy"]
+type1 = ["xattr ; sys_platform == \"darwin\""]
+unicode = ["unicodedata2 (>=17.0.0) ; python_version <= \"3.14\""]
+woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "googleapis-common-protos"
@@ -656,6 +837,133 @@ files = [
 ]
 
 [[package]]
+name = "kiwisolver"
+version = "1.5.0"
+description = "A fast implementation of the Cassowary constraint solver"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86e0287879f75621ae85197b0877ed2f8b7aa57b511c7331dce2eb6f4de7d476"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9190426b7aa26c5229501fa297b8d0653cfd3f5a36f7990c264e157cbf886b3b"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c8277104ded0a51e699c8c3aff63ce2c56d4ed5519a5f73e0fd7057f959a2b9e"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f9baf6f0a6e7571c45c8863010b45e837c3ee1c2c77fcd6ef423be91b21fedb"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cff8e5383db4989311f99e814feeb90c4723eb4edca425b9d5d9c3fefcdd9537"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ebae99ed6764f2b5771c522477b311be313e8841d2e0376db2b10922daebbba4"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d5cd5189fc2b6a538b75ae45433140c4823463918f7b1617c31e68b085c0022c"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f42c23db5d1521218a3276bb08666dcb662896a0be7347cba864eca45ff64ede"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:94eff26096eb5395136634622515b234ecb6c9979824c1f5004c6e3c3c85ccd2"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:dd952e03bfbb096cfe2dd35cd9e00f269969b67536cb4370994afc20ff2d0875"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf4679a3d71012a7c2bf360e5cd878fbd5e4fcac0896b56393dec239d81529ed"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41024ed50e44ab1a60d3fe0a9d15a4ccc9f5f2b1d814ff283c8d01134d5b81bc"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1"},
+    {file = "kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"},
+]
+
+[[package]]
 name = "langfuse"
 version = "4.0.1"
 description = "A client library for accessing langfuse"
@@ -825,6 +1133,85 @@ files = [
 ]
 
 [[package]]
+name = "matplotlib"
+version = "3.10.9"
+description = "Python plotting package"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "matplotlib-3.10.9-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77210dce9cb8153dffc967efaae990543392563d5a376d4dd8539bebcb0ed217"},
+    {file = "matplotlib-3.10.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1e7698ac9868428e84d2c967424803b2472ff7167d9d6590d4204ed775343c3b"},
+    {file = "matplotlib-3.10.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1aa972116abb4c9d201bf245620b433726cb6856f3bef6a78f776a00f5c92d37"},
+    {file = "matplotlib-3.10.9-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae2f11957b27ce53497dd4d7b235c4d4f1faf383dfb39d0c5beb833bff883294"},
+    {file = "matplotlib-3.10.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b049278ddce116aaa1c1377ebf58adea909132dfce0281cf7e3a1ea9fc2e2c65"},
+    {file = "matplotlib-3.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:82834c3c292d24d3a8aae77cd2d20019de69d692a34a970e4fdb8d33e2ea3dda"},
+    {file = "matplotlib-3.10.9-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:68cfdcede415f7c8f5577b03303dd94526cdb6d11036cecdc205e08733b2d2bb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfca0129678bd56379db26c52b5d77ed7de314c047492fbdc763aa7501710cfb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e436d155fa8a3399dc62683f8f5d0e2e50d25d0144a73edd73f82eec8f4abfb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56fc0bd271b00025c6edfdc7c2dcd247372c8e1544971d62e1dc7c17367e8bf9"},
+    {file = "matplotlib-3.10.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a5a6104ed666402ba5106d7f36e0e0cdca4e8d7fa4d39708ca88019e2835a2eb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:d730e984eddf56974c3e72b6129c7ca462ac38dc624338f4b0b23eb23ecba00f"},
+    {file = "matplotlib-3.10.9-cp311-cp311-win_arm64.whl", hash = "sha256:51bf0ddbdc598e060d46c16b5590708f81a1624cefbaaf62f6a81bf9285b8c80"},
+    {file = "matplotlib-3.10.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0c3c28d9fbcc1fe7a03be236d73430cf6409c41fb2383a7ac52fe932b072cb1"},
+    {file = "matplotlib-3.10.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cb28c2bd769aa3e98322c6ab09854cbcc52ab69d2759d681bba3e327b2b320"},
+    {file = "matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285"},
+    {file = "matplotlib-3.10.9-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c63ebcd8b4b169eb2f5c200552ae6b8be8999a005b6b507ed76fb8d7d674fe2"},
+    {file = "matplotlib-3.10.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d75d11c949914165976c621b2324f9ef162af7ebf4b057ddf95dd1dba7e5edcf"},
+    {file = "matplotlib-3.10.9-cp312-cp312-win_amd64.whl", hash = "sha256:d091f9d758b34aaaaa6331d13574bf01891d903b3dec59bfff458ef7551de5d6"},
+    {file = "matplotlib-3.10.9-cp312-cp312-win_arm64.whl", hash = "sha256:10cc5ce06d10231c36f40e875f3c7e8050362a4ee8f0ee5d29a6b3277d57bb42"},
+    {file = "matplotlib-3.10.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b580440f1ff81a0e34122051a3dfabb7e4b7f9e380629929bde0eff9af72165f"},
+    {file = "matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e"},
+    {file = "matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f"},
+    {file = "matplotlib-3.10.9-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a8d66a55def891c33147ba3ba9bfcabf0b526a43764c818acbb4525e5ed0838"},
+    {file = "matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2"},
+    {file = "matplotlib-3.10.9-cp313-cp313-win_amd64.whl", hash = "sha256:f4399f64b3e94cd500195490972ae1ee81170df1636fa15364d157d5bdd7b921"},
+    {file = "matplotlib-3.10.9-cp313-cp313-win_arm64.whl", hash = "sha256:ba7b3b8ef09eab7df0e86e9ae086faa433efbfbdb46afcb3aa16aabf779469a8"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:09218df8a93712bd6ea133e83a153c755448cf7868316c531cffcc43f69d1cc9"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de2445a0c6690d21b7eb6ce071cebad6d40a2e9bdf10d039074a96ba19797b99"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9fae004b941b23ff2edcf1567a857ed77bafc8086ffa258190462328434faf8"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-win_arm64.whl", hash = "sha256:6b63d9c7c769b88ab81e10dc86e4e0607cf56817b9f9e6cf24b2a5f1693b8e38"},
+    {file = "matplotlib-3.10.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:172db52c9e683f5d12eaf57f0f54834190e12581fe1cc2a19595a8f5acb4e77d"},
+    {file = "matplotlib-3.10.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97e35e8d39ccc85859095e01a53847432ba9a53ddf7986f7a54a11b73d0e143f"},
+    {file = "matplotlib-3.10.9-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aba1615dabe83188e19d4f75a253c6a08423e04c1425e64039f800050a69de6b"},
+    {file = "matplotlib-3.10.9-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34cf8167e023ad956c15f36302911d5406bd99a9862c1a8499ea6f7c0e015dc2"},
+    {file = "matplotlib-3.10.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59476c6d29d612b8e9bb6ce8c5b631be6ba8f9e3a2421f22a02b192c7dd28716"},
+    {file = "matplotlib-3.10.9-cp314-cp314-win_amd64.whl", hash = "sha256:336b9acc64d309063126edcdaca00db9373af3c476bb94388fe9c5a53ad13e6f"},
+    {file = "matplotlib-3.10.9-cp314-cp314-win_arm64.whl", hash = "sha256:2dc9477819ffd78ad12a20df1d9d6a6bd4fec6aaa9072681465fddca052f1456"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:da4e09638420548f31c354032a6250e473c68e5a4e96899b4844cf39ddea23fe"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:345f6f68ecc8da0ca56fad2ea08fde1a115eda530079eca185d50a7bc3e146c6"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4edcfbd8565339aa62f1cd4012f7180926fdbe71850f7b0d3c379c175cd6b66c"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6be157fe17fc37cb95ac1d7374cf717ce9259616edec911a78d9d26dae8522d4"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c"},
+    {file = "matplotlib-3.10.9-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1872fb212a05b729e649754a72d5da61d03e0554d76e80303b6f83d1d2c0552b"},
+    {file = "matplotlib-3.10.9-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:985f2238880e2e69093f588f5fe2e46771747febf0649f3cf7f7b7480875317f"},
+    {file = "matplotlib-3.10.9-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6640f75af2c6148293caa0a2b39dd806a492dd66c8a8b04035813e33d0fd2585"},
+    {file = "matplotlib-3.10.9-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:42fb814efabe95c06c1994d8ab5a8385f43a249e23badd3ba931d4308e5bca20"},
+    {file = "matplotlib-3.10.9-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f76e640a5268850bfda54b5131b1b1941cc685e42c5fa98ed9f2d64038308cba"},
+    {file = "matplotlib-3.10.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3fc0364dfbe1d07f6d15c5ebd0c5bf89e126916e5a8667dd4a7a6e84c36653d4"},
+    {file = "matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358"},
+]
+
+[package.dependencies]
+contourpy = ">=1.0.1"
+cycler = ">=0.10"
+fonttools = ">=4.22.0"
+kiwisolver = ">=1.3.1"
+numpy = ">=1.23"
+packaging = ">=20.0"
+pillow = ">=8"
+pyparsing = ">=3"
+python-dateutil = ">=2.7"
+
+[package.extras]
+dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7,<10)"]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 description = "Inline Matplotlib backend for Jupyter"
@@ -911,6 +1298,88 @@ groups = ["dev"]
 files = [
     {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
     {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6"},
+    {file = "numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8"},
+    {file = "numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147"},
+    {file = "numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2"},
+    {file = "numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45"},
+    {file = "numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751"},
+    {file = "numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605"},
+    {file = "numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91"},
+    {file = "numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359"},
+    {file = "numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd"},
+    {file = "numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb"},
+    {file = "numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1"},
+    {file = "numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261"},
+    {file = "numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4"},
+    {file = "numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73"},
+    {file = "numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda"},
 ]
 
 [[package]]
@@ -1057,6 +1526,98 @@ files = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "pandas-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:455f6f8139d4282188f526868dbc3c828470e88a3d9d59a891bd46a455f21b98"},
+    {file = "pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e15135e2ee5df1063313e2425ceef8ac0f4ae775893815b0923651b806a5639"},
+    {file = "pandas-3.0.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f1f1752b8533ea03f7f39a9c15b1a058d067bb48f4748948e7a8691e0510f2"},
+    {file = "pandas-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a1e45c80cceb3b4a21bc5939d52e8cbd8d9b7305309219d59e9754d9ce09e27"},
+    {file = "pandas-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:14da8316da4d0c5a77618425996bfb1248ca87fc2c1486e6fde4652bd18b5824"},
+    {file = "pandas-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a55066a0505dae0ba2b50a46637db34b46f9094c65c5d4800794ef6335010938"},
+    {file = "pandas-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6674ab18ad8c57802867264b00e15e7bb904700cdd9046e3b2fa1fce237439ea"},
+    {file = "pandas-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:5cc09a68b3120e0f54870dede8287a7bb1fa463907e4fcec1ea77cab6179bf7a"},
+    {file = "pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09"},
+    {file = "pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4"},
+    {file = "pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c"},
+    {file = "pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9"},
+    {file = "pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf"},
+    {file = "pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c"},
+    {file = "pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc"},
+    {file = "pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49"},
+    {file = "pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa"},
+    {file = "pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7"},
+    {file = "pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8"},
+    {file = "pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a"},
+    {file = "pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb"},
+    {file = "pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2"},
+    {file = "pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44"},
+    {file = "pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e"},
+    {file = "pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d"},
+    {file = "pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066"},
+    {file = "pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd"},
+    {file = "pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085"},
+    {file = "pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870"},
+    {file = "pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f"},
+    {file = "pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13"},
+    {file = "pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac"},
+    {file = "pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f"},
+    {file = "pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb"},
+    {file = "pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a"},
+    {file = "pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360"},
+    {file = "pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76"},
+    {file = "pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5"},
+    {file = "pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977"},
+    {file = "pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04"},
+    {file = "pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6"},
+    {file = "pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c"},
+    {file = "pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028"},
+    {file = "pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d"},
+    {file = "pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a"},
+    {file = "pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1"},
+    {file = "pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1"},
+    {file = "pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.26.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.3.3", markers = "python_version >= \"3.14\""},
+]
+python-dateutil = ">=2.8.2"
+tzdata = {version = "*", markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""}
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)", "beautifulsoup4 (>=4.12.3)", "bottleneck (>=1.4.2)", "fastparquet (>=2024.11.0)", "fsspec (>=2024.10.0)", "gcsfs (>=2024.10.0)", "html5lib (>=1.1)", "hypothesis (>=6.116.0)", "jinja2 (>=3.1.5)", "lxml (>=5.3.0)", "matplotlib (>=3.9.3)", "numba (>=0.60.0)", "numexpr (>=2.10.2)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "psycopg2 (>=2.9.10)", "pyarrow (>=13.0.0)", "pyiceberg (>=0.8.1)", "pymysql (>=1.1.1)", "pyreadstat (>=1.2.8)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)", "python-calamine (>=0.3.0)", "pytz (>=2020.1)", "pyxlsb (>=1.0.10)", "qtpy (>=2.4.2)", "s3fs (>=2024.10.0)", "scipy (>=1.14.1)", "tables (>=3.10.1)", "tabulate (>=0.9.0)", "xarray (>=2024.10.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)", "zstandard (>=0.23.0)"]
+aws = ["s3fs (>=2024.10.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.4.2)"]
+compression = ["zstandard (>=0.23.0)"]
+computation = ["scipy (>=1.14.1)", "xarray (>=2024.10.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "python-calamine (>=0.3.0)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)"]
+feather = ["pyarrow (>=13.0.0)"]
+fss = ["fsspec (>=2024.10.0)"]
+gcp = ["gcsfs (>=2024.10.0)"]
+hdf5 = ["tables (>=3.10.1)"]
+html = ["beautifulsoup4 (>=4.12.3)", "html5lib (>=1.1)", "lxml (>=5.3.0)"]
+iceberg = ["pyiceberg (>=0.8.1)"]
+mysql = ["SQLAlchemy (>=2.0.36)", "pymysql (>=1.1.1)"]
+output-formatting = ["jinja2 (>=3.1.5)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=13.0.0)"]
+performance = ["bottleneck (>=1.4.2)", "numba (>=0.60.0)", "numexpr (>=2.10.2)"]
+plot = ["matplotlib (>=3.9.3)"]
+postgresql = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "psycopg2 (>=2.9.10)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+spss = ["pyreadstat (>=1.2.8)"]
+sql-other = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)"]
+test = ["hypothesis (>=6.116.0)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)"]
+timezone = ["pytz (>=2020.1)"]
+xml = ["lxml (>=5.3.0)"]
+
+[[package]]
 name = "parso"
 version = "0.8.6"
 description = "A Python Parser"
@@ -1087,6 +1648,115 @@ files = [
 
 [package.dependencies]
 ptyprocess = ">=0.5"
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+description = "Python Imaging Library (fork)"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f"},
+    {file = "pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c"},
+    {file = "pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3"},
+    {file = "pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa"},
+    {file = "pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032"},
+    {file = "pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5"},
+    {file = "pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024"},
+    {file = "pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab"},
+    {file = "pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176"},
+    {file = "pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b"},
+    {file = "pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909"},
+    {file = "pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808"},
+    {file = "pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60"},
+    {file = "pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe"},
+    {file = "pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5"},
+    {file = "pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780"},
+    {file = "pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5"},
+    {file = "pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5"},
+    {file = "pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940"},
+    {file = "pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5"},
+    {file = "pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414"},
+    {file = "pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c"},
+    {file = "pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2"},
+    {file = "pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c"},
+    {file = "pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795"},
+    {file = "pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3"},
+    {file = "pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9"},
+    {file = "pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795"},
+    {file = "pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e"},
+    {file = "pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b"},
+    {file = "pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06"},
+    {file = "pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b"},
+    {file = "pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4"},
+    {file = "pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4"},
+    {file = "pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea"},
+    {file = "pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24"},
+    {file = "pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98"},
+    {file = "pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453"},
+    {file = "pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8"},
+    {file = "pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b"},
+    {file = "pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295"},
+    {file = "pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed"},
+    {file = "pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286"},
+    {file = "pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50"},
+    {file = "pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104"},
+    {file = "pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7"},
+    {file = "pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150"},
+    {file = "pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1"},
+    {file = "pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463"},
+    {file = "pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e"},
+    {file = "pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06"},
+    {file = "pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43"},
+    {file = "pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354"},
+    {file = "pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1"},
+    {file = "pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e"},
+    {file = "pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["arro3-compute", "arro3-core", "nanoarrow", "pyarrow"]
+tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma (>=5)", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
+xmp = ["defusedxml"]
 
 [[package]]
 name = "platformdirs"
@@ -1387,6 +2057,21 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+description = "pyparsing - Classes and methods to define and execute parsing grammars"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
+    {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
 name = "pyright"
 version = "1.1.409"
 description = "Command line wrapper for pyright"
@@ -1466,6 +2151,21 @@ pytest = ">=6.2.5"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
@@ -1660,6 +2360,40 @@ files = [
     {file = "ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d"},
     {file = "ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f"},
     {file = "ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6"},
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+description = "Statistical data visualization"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987"},
+    {file = "seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7"},
+]
+
+[package.dependencies]
+matplotlib = ">=3.4,<3.6.1 || >3.6.1"
+numpy = ">=1.20,<1.24.0 || >1.24.0"
+pandas = ">=1.2"
+
+[package.extras]
+dev = ["flake8", "flit", "mypy", "pandas-stubs", "pre-commit", "pytest", "pytest-cov", "pytest-xdist"]
+docs = ["ipykernel", "nbconvert", "numpydoc", "pydata_sphinx_theme (==0.10.0rc2)", "pyyaml", "sphinx (<6.0.0)", "sphinx-copybutton", "sphinx-design", "sphinx-issues"]
+stats = ["scipy (>=1.7)", "statsmodels (>=0.12)"]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -1971,6 +2705,19 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["dev"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""
+files = [
+    {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
+    {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
+]
+
+[[package]]
 name = "uc-micro-py"
 version = "2.0.0"
 description = "Micro subset of unicode data files for linkify-it-py projects."
@@ -2252,4 +2999,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "49facd57ff3756b33f607af416fb2660e47de4780934a338c226150df0d91b1e"
+content-hash = "777800f36d742cb2fe00c7da17aedb0d706848c7b5ffd5ce28e9c67856889b1f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ roman-numerals = "^4.1.0"
 textual-hmr = "^0.0.2"
 ruff = "^0.15.12"
 pyright = "^1.1.409"
+seaborn = "^0.13.2"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/skills/simplellmfunc-developer/SKILL.md
+++ b/skills/simplellmfunc-developer/SKILL.md
@@ -207,6 +207,7 @@ Do not introduce code that directly mutates `ContextState.messages` outside of `
 - TDD, tests, and validation expectations: `reference/testing-and-tdd.md`
 - Coding conventions and naming rules: `reference/style-and-spec.md`
 - Framework-specific gotchas: `reference/framework-gotchas.md`
+- PyRepl architecture, IPC, primitive RPC, event streaming, and image artifact capture: `reference/pyrepl-architecture.md`
 - Docs and examples workflow: `reference/docs-and-examples.md`
 - Maintainer workflow notes: `reference/AGENT.md`
 - Contributor guide: `reference/contributing.md`

--- a/skills/simplellmfunc-developer/SKILL.md
+++ b/skills/simplellmfunc-developer/SKILL.md
@@ -125,7 +125,7 @@ Message and tool sub-modules:
 ### Infrastructure
 - `logger/`: structured logging, trace_id, async context manager
 - `observability/`: Langfuse trace/span integration
-- `type/`: multimodal types (`Text`, `ImgUrl`, `ImgPath`)
+- `type/`: multimodal types (`Text`, `ImgUrl`, `ImgPath`) and canonical chat input (`UserChatMessage`)
 - `utils/tui/`: Textual TUI integration
 
 ### Tests (`tests/`)
@@ -174,6 +174,7 @@ Do not introduce code that directly mutates `ContextState.messages` outside of `
 
 ### Decorator rules
 - `@llm_function` returns `LLMFunction`; `@llm_chat` returns `LLMChat`. Preserve function-like metadata (`__wrapped__`, `__name__`, `__doc__`, `__annotations__`, `__signature__`) when changing them.
+- Multimodal input policy: `llm_function` should use explicit `ImgUrl` / `ImgPath` typed parameters, while `llm_chat` should prefer one OpenAI-compatible `UserChatMessage` user-message object.
 - Do not reintroduce closure-only wrapper implementations for SelfRef binding; SelfRef should bind the stable `LLMChat` instance.
 - There is no `enable_event` or `return_mode` decorator parameter; `llm_chat` always yields `ReactOutput`, and `llm_function.stream(...)` yields `ReactOutput`.
 - Prefer `async def` for decorated public patterns and tool implementations.

--- a/skills/simplellmfunc-developer/reference/pyrepl-architecture.md
+++ b/skills/simplellmfunc-developer/reference/pyrepl-architecture.md
@@ -1,0 +1,359 @@
+# PyRepl Architecture Notes
+
+Use this reference when changing PyRepl, runtime primitives, tool execution, event streams, or multimodal tool outputs.
+
+## Core mental model
+
+`PyRepl` is a public facade over a persistent IPython worker process. The main process owns the tool protocol, ReAct events, primitive registry, SelfRef state, and transcript mutations. The worker process owns Python code execution and the persistent user namespace.
+
+```text
+LLM tool call: execute_code(...)
+        |
+        v
+main process: PyRepl facade / ReAct tool scheduler / ToolEventEmitter
+        |
+        | multiprocessing queues: command_queue / event_queue
+        v
+worker process: IPython InteractiveShell + persistent namespace
+        |
+        v
+runtime proxy: runtime.selfref.* / runtime.<pack>.* primitive RPC back to main process
+```
+
+Important boundaries:
+
+- Worker code must not mutate ReAct transcript/history directly.
+- Runtime primitives are not native LLM tool calls. They are host-registered callables invoked inside `execute_code` through the injected `runtime` proxy.
+- Tool results enter model-visible history through `ContextMutation` objects, usually `ToolResultMutation` or `MultimodalToolResultMutation`.
+
+## File map
+
+- `SimpleLLMFunc/builtin/pyrepl.py`: public `PyRepl` facade composed from focused mixins.
+- `SimpleLLMFunc/builtin/pyrepl_worker_client.py`: subprocess and multiprocessing queue lifecycle.
+- `SimpleLLMFunc/builtin/pyrepl_worker_mixin.py`: facade-compatible wrappers around the worker client.
+- `SimpleLLMFunc/builtin/pyrepl_execution.py`: main-process `execute()` / `reset()` orchestration, timeout handling, event polling, event-emitter forwarding, audit payload assembly.
+- `SimpleLLMFunc/builtin/pyrepl_worker.py`: worker-process IPython shell, stdout/stderr capture, `input()` hook, primitive RPC transport, image artifact capture.
+- `SimpleLLMFunc/builtin/pyrepl_primitive_host.py`: main-process primitive registry/backend host and primitive call execution.
+- `SimpleLLMFunc/builtin/pyrepl_tools.py`: `execute_code` / `reset_repl` tool definitions, output formatting, and artifact-to-multimodal return conversion.
+- `SimpleLLMFunc/runtime/worker_proxy.py`: worker-side dynamic `runtime` proxy and dotted namespace builder.
+- `SimpleLLMFunc/runtime/primitives.py`: `PrimitivePack`, `PrimitiveRegistry`, `PrimitiveCallContext`, primitive metadata/spec contracts.
+
+## Worker lifecycle and IPC
+
+The main process starts the worker through `PyReplWorkerClient.ensure_worker(...)` using `multiprocessing.get_context("spawn")`.
+
+Startup sequence:
+
+1. Create `command_queue` and `event_queue`.
+2. Spawn a daemon worker process targeting `run_pyrepl_worker(command_queue, event_queue, working_directory)`.
+3. Worker constructs `_PyReplWorker`, then emits `EVENT_WORKER_READY`.
+4. Main process waits up to 10 seconds for `EVENT_WORKER_READY`, while preserving unexpected startup events in `prefetched_events`.
+
+Main-to-worker command messages are plain dicts:
+
+```python
+{"type": "execute", "exec_id": "...", "code": "...", ...}
+{"type": "reset", "request_id": "..."}
+{"type": "input_reply", "request_id": "...", "value": "..."}
+{"type": "primitive_result", "call_id": "...", "ok": True, "result": ...}
+{"type": "shutdown"}
+```
+
+Worker-to-main event messages are also plain dicts:
+
+```python
+{"type": "stdout", "exec_id": "...", "text": "..."}
+{"type": "stderr", "exec_id": "...", "text": "..."}
+{"type": "input_request", "exec_id": "...", "request_id": "...", "prompt": "..."}
+{"type": "primitive_call", "exec_id": "...", "call_id": "...", "name": "...", "args": [...], "kwargs": {...}}
+{"type": "execute_result", "exec_id": "...", "return_value": ..., "artifacts": [...], ...}
+```
+
+`PyReplWorkerMixin._start_execute_worker_command(...)` is the start boundary for one execution. It ensures the worker is alive, drains stale events, then sends `COMMAND_EXECUTE`.
+
+`PyReplExecutionMixin.execute(...)` is the main orchestration loop. It polls worker events with `_receive_worker_event(...)`, which uses `asyncio.to_thread(event_queue.get, ...)` so queue reads do not block the asyncio loop.
+
+Each execution has a fresh `exec_id`. The main process ignores stdout/stderr/input/result events whose `exec_id` does not match the active execution.
+
+## Code execution in the worker
+
+The worker hosts an `IPython.core.interactiveshell.InteractiveShell` and keeps its `user_ns` as the persistent namespace.
+
+`_PyReplWorker._execute_python_code(...)` implements IPython-like last-expression behavior:
+
+1. Transform the cell with `InteractiveShell.transform_cell(...)`.
+2. Parse as an AST module.
+3. If the last node is an expression, split it from the body.
+4. `exec(...)` the body nodes in the persistent namespace.
+5. `eval(...)` the last expression in the same namespace.
+6. Return `repr(result)` unless the result is `None` or recognized as an image artifact.
+
+This preserves normal REPL state across calls: variables defined in one `execute_code` call remain available in the next call until `reset_repl` clears the namespace.
+
+## stdout and stderr capture
+
+stdout/stderr capture happens inside the worker process.
+
+Before executing user code, `_handle_execute(...)` temporarily replaces:
+
+```python
+sys.stdout = _LineCapture(on_stdout)
+sys.stderr = _LineCapture(on_stderr)
+```
+
+`_LineCapture` is a line-buffered `io.TextIOBase` adapter. It accumulates writes until it sees `\n`, then emits complete lines through its callback. `flush()` emits any remaining partial line.
+
+Callbacks emit worker events:
+
+```python
+def on_stdout(text: str) -> None:
+    self._emit(EVENT_STDOUT, exec_id=exec_id, text=text)
+
+def on_stderr(text: str) -> None:
+    self._emit(EVENT_STDERR, exec_id=exec_id, text=text)
+```
+
+The main process receives these events in `PyReplExecutionMixin.execute(...)`, appends text to `stdout_parts` / `stderr_parts`, and forwards live custom events when an event emitter is available.
+
+There are two output paths:
+
+```text
+worker stdout capture -> event_queue -> stdout_parts -> final execute result / tool summary
+worker stdout capture -> event_queue -> ToolEventEmitter -> ReAct CustomEvent stream
+```
+
+## ToolEventEmitter path
+
+`PyRepl` does not own a global event stream. The ReAct tool scheduler creates one `ToolEventEmitter` per tool call.
+
+Flow:
+
+1. `schedule_tool_batch(...)` creates `ToolEventEmitter` with trace, function, iteration, tool name, and tool call id metadata.
+2. `execute_single_tool_call_result(...)` detects that `execute_code` accepts an `event_emitter` parameter and injects it.
+3. `PyReplExecutionMixin.execute(...)` forwards worker events by calling `event_emitter.emit(...)`.
+
+Emitted PyRepl custom events:
+
+- `kernel_stdout`: `{"text": "..."}`
+- `kernel_stderr`: `{"text": "..."}`
+- `kernel_input_request`: `{"request_id": "...", "prompt": "...", "idle_timeout_seconds": ...}`
+
+These become `CustomEvent` values in the `ReactOutput` stream. The final tool result remains separate from live event streaming.
+
+## `input()` bridge
+
+The worker temporarily replaces `builtins.input` with `input_hook` during execution.
+
+When user code calls `input(prompt)`:
+
+1. Worker generates a `request_id`.
+2. Worker emits `EVENT_INPUT_REQUEST` with the prompt and idle timeout.
+3. Worker waits for a matching `COMMAND_INPUT_REPLY`.
+4. Main process either reads from real stdin when no event emitter exists, or exposes the request through `kernel_input_request` so UI code can call `PyRepl.submit_input(request_id, value)`.
+
+The main process resets the active execution deadline when input is accepted. This means waiting for user input does not consume the normal execution timeout window.
+
+## Runtime primitive injection and RPC
+
+The worker never directly imports or owns host primitive backends. Instead, the worker namespace receives a global `runtime` object from `WorkerRuntimeProxy`.
+
+Injection point:
+
+- `_PyReplWorker._sync_runtime_binding(...)` sets `self._namespace["runtime"] = self._runtime_proxy` when runtime support is enabled.
+
+Dynamic call shape:
+
+```python
+runtime.selfref.context.inspect()
+runtime.selfref.fork.spawn(...)
+runtime.call("selfref.context.remember", "fact")
+```
+
+`WorkerRuntimeProxy.__getattr__` returns a `WorkerRuntimeNamespace`; each dotted attribute extends the path. Calling the namespace invokes `transport.call_primitive(name=path, args=list(args), kwargs=kwargs)`.
+
+The worker transport is `_PyReplWorker.call_primitive(...)`:
+
+1. Generate `call_id`.
+2. Emit `EVENT_PRIMITIVE_CALL` with `name`, `args`, and `kwargs`.
+3. Block inside the worker waiting for matching `COMMAND_PRIMITIVE_RESULT`.
+4. Return `result` if `ok=True`, otherwise raise a reconstructed error.
+
+The main process handles primitive calls in `PyReplExecutionMixin.execute(...)` when it sees `EVENT_PRIMITIVE_CALL`. It calls `PyReplPrimitiveHostMixin._execute_primitive_call(...)`, sends the response back as `COMMAND_PRIMITIVE_RESULT`, then continues polling.
+
+Primitive handlers receive a `PrimitiveCallContext` containing:
+
+- `primitive_name`
+- `call_id`
+- `execution_id`
+- `event_emitter`
+- metadata such as `pyrepl_instance_id`
+- the host `repl`
+- the primitive `registry`
+- resolved backend fields when applicable
+
+This lets primitives emit events, access host backends, and queue SelfRef changes without directly mutating the worker namespace or ReAct transcript.
+
+## Primitive packs and discovery
+
+`PrimitivePack` is the declarative extension unit. A pack has:
+
+- `name`: namespace used in `runtime.<name>.*`
+- `backend_name`: host backend lookup name
+- `backend`: host-side object/state
+- `guidance`: prompt-injection guidance for the model
+- primitive entries with handler and public contract metadata
+
+Install path:
+
+```python
+pack = repl.pack("demo", backend=object(), guidance="...")
+
+@pack.primitive("ping")
+def ping(ctx): ...
+
+repl.install_pack(pack)
+```
+
+`PyReplPrimitiveHostMixin` registers pack entries into `PrimitiveRegistry` and stores the backend under the pack/backend namespace. Built-in SelfRef primitives are installed by default unless disabled for internal cloning/tests.
+
+Discovery primitives are exposed through the same runtime proxy:
+
+- `runtime.list_primitives()`
+- `runtime.list_primitive_specs(...)`
+- `runtime.get_primitive_spec(name)`
+- `runtime.list_backends()`
+
+`_build_execute_tool_prompt_injection(...)` renders the installed primitive pack guidance into the tool-owned system prompt block so the model knows how to discover and call runtime primitives.
+
+## Image artifact capture
+
+Image capture happens inside `_PyReplWorker._execute_python_code(...)` and returns structured artifacts in the final `execute_result` event.
+
+Supported sources:
+
+- explicit `display(Image(...))`
+- image-rich last expressions such as `Image(filename="chart.png")`
+- last expression returning `ImgPath(...)`
+- last expression returning `ImgUrl(...)`
+- rich repr methods such as `_repr_png_()` and `_repr_jpeg_()`
+- IPython MIME bundles containing `image/png`, `image/jpeg`, `image/gif`, `image/bmp`, or `image/webp`
+
+Worker artifact shape for local images:
+
+```python
+{
+    "type": "image",
+    "source": "display_data" | "return_value",
+    "path": "/tmp/pyrepl_image_xxx.png",
+    "mime_type": "image/png",
+    "detail": "auto",
+}
+```
+
+Worker artifact shape for URL images:
+
+```python
+{
+    "type": "image",
+    "source": "return_value",
+    "url": "https://..." | "data:image/png;base64,...",
+    "detail": "auto" | "low" | "high",
+}
+```
+
+Local image data is written to a temp file by `_write_image_artifact(...)` instead of sending large binary payloads through the queue. The main process later wraps these paths as `ImgPath`.
+
+`display(...)` handling has a special hook:
+
+- Image objects are captured and suppressed from normal display output.
+- Non-image objects are passed through to the original IPython `display`, preserving text/plain output.
+- Mixed calls like `display(Image(...), "note")` capture the image and preserve the text output.
+
+## Tool return conversion for images
+
+`PyRepl.execute(...)` returns raw structured data including `artifacts`.
+
+The `execute_code` tool path converts artifacts in `pyrepl_tools.build_execute_tool_return(...)`:
+
+- no images: return the normal summary string
+- images present: return `(summary, list[ImgPath | ImgUrl])`
+
+The generic tool execution layer in `base/tool_call/execution.py` supports multimodal tool returns:
+
+- `ImgPath`
+- `ImgUrl`
+- `list[ImgPath | ImgUrl]`
+- `(str, ImgPath)`
+- `(str, ImgUrl)`
+- `(str, list[ImgPath | ImgUrl])`
+
+These become `ExecutedToolCallResult(is_multimodal=True, messages=[user_multimodal_message])`.
+
+Then `schedule_tool_batch(...)` converts that into `MultimodalToolResultMutation`. At compile time, `context_compile._append_multimodal_tool_result_mutation(...)` removes the original assistant tool call from the transcript and appends:
+
+1. an assistant explanation message
+2. a user message containing OpenAI-compatible multimodal content parts
+
+This is intentional because normal OpenAI `tool` messages cannot directly carry image content.
+
+## Provider adapter boundary
+
+Chat Completions-style providers accept user content parts like:
+
+```python
+{"type": "text", "text": "..."}
+{"type": "image_url", "image_url": {"url": "...", "detail": "high"}}
+```
+
+`OpenAIResponsesCompatible` must translate those into Responses input parts:
+
+```python
+{"type": "input_text", "text": "..."}
+{"type": "input_image", "image_url": "...", "detail": "high"}
+```
+
+Keep this wire-format conversion inside `interface/openai_responses_compatible.py`; do not leak Responses-specific shapes into ReAct, PyRepl, or decorator code.
+
+## Tests to run
+
+For PyRepl worker/protocol changes:
+
+```bash
+uv run pytest tests/test_builtin/test_pyrepl.py
+```
+
+For tool multimodal return changes:
+
+```bash
+uv run pytest tests/test_base/test_tool_call tests/test_base/test_react_core_scheduler.py
+```
+
+For provider boundary changes:
+
+```bash
+uv run pytest tests/test_interface/test_openai_responses_compatible.py
+```
+
+For broader regression after PyRepl/tool changes:
+
+```bash
+uv run pytest tests/test_base/test_tool_call tests/test_base/test_react_core_scheduler.py tests/test_builtin/test_pyrepl.py tests/test_llm_function_decorator.py tests/test_llm_chat_decorator.py tests/test_interface/test_openai_responses_compatible.py
+```
+
+Run lint on touched Python files with:
+
+```bash
+uv run ruff check <changed-python-files>
+```
+
+## Common pitfalls
+
+- Do not send image bytes directly through queues unless there is a strong reason. Prefer temp files plus artifact metadata.
+- Do not let primitives edit ReAct transcript/history directly. Use host-side SelfRef APIs and mutations.
+- Do not treat runtime primitives as native LLM tools. The model calls them inside `execute_code` through `runtime.*`.
+- Keep worker event messages JSON-ish / pickle-safe. They cross a multiprocessing queue.
+- Preserve `exec_id` filtering; otherwise stale worker events can corrupt the current execution.
+- Preserve stdout/stderr final aggregation even when streaming custom events are emitted.
+- Preserve non-image `display(...)` behavior when adding image capture hooks.
+- Keep provider-specific multimodal wire-format conversions in provider adapters.
+- When `too_long_to_file=True` and a tool returns `(summary, images)`, apply long-output truncation to the text summary as well as plain string results.

--- a/skills/simplellmfunc-developer/reference/spec/project-map.md
+++ b/skills/simplellmfunc-developer/reference/spec/project-map.md
@@ -290,10 +290,11 @@ SimpleLLMFunc/
 
 **子模块**:
 
-- `message.py`: 消息类型
+- `message.py`: 消息类型与 OpenAI-compatible content part 类型
+- `chat_input.py`: `UserChatMessage` canonical chat user input object
 - `tool_call.py`: 工具调用类型
 - `llm.py`: LLM 相关类型
-- `multimodal.py`: 多模态类型
+- `multimodal.py`: 多模态基础类型（`Text` / `ImgUrl` / `ImgPath`）
 - `hooks.py`: 事件相关类型
 
 ### logger 模块

--- a/skills/simplellmfunc/SKILL.md
+++ b/skills/simplellmfunc/SKILL.md
@@ -473,6 +473,7 @@ asyncio.run(main())
 - There is no `enable_event` or `return_mode` decorator option. Do not write old `(chunk, history)` consumers.
 - `too_long_to_file=True` keeps roughly the first 20000 tokens in chat and writes the full tool result to a temp file.
 - `PyRepl.reset()` clears REPL variables but keeps runtime backends and self-reference memory.
+- `execute_code` returns image-producing code as multimodal tool output when code uses `display(Image(...))`, returns an image-rich last expression, or returns `ImgPath` / `ImgUrl`.
 - In 0.8.1, PyRepl and SelfRef were internally split into facade/component modules, but application code should continue using the same public surfaces: `PyRepl`, `SelfReference`, `runtime.selfref.context.*`, and `runtime.selfref.fork.*`.
 - `runtime.selfref.context.compact(...)` is queued first. When called from a tool run, the compacted context is applied before the next same-turn LLM step when possible, and finalize still commits any leftover queued compaction before the turn ends.
 - `OpenAIResponsesCompatible` is a first-class adapter. It maps the selected system prompt to Responses `instructions`, supports `reasoning={...}`, and keeps Responses-specific request/stream behavior out of your decorator code.

--- a/skills/simplellmfunc/SKILL.md
+++ b/skills/simplellmfunc/SKILL.md
@@ -35,6 +35,7 @@ This is critical for writing good prompts in SimpleLLMFunc: your docstring is im
   - plain-text or XML output constraints depending on the return type
 - If tools are mounted, the framework prepends a deduplicated `<tool_best_practices>` block before the main system prompt.
 - Runtime argument values are not put in the system prompt; they go into the user prompt.
+- For image input, keep the function-like style: declare explicit parameters as `ImgUrl`, `ImgPath`, or lists/unions of those types. Use `ImgUrl` for web/data URLs and `ImgPath` for local files.
 
 Write `llm_function` docstrings as task policy, quality bar, constraints, and style guidance. Do not waste docstring space restating parameter schemas or low-level output formatting that the framework already injects.
 
@@ -45,6 +46,7 @@ Write `llm_function` docstrings as task policy, quality bar, constraints, and st
 - Then the framework prepends `<tool_best_practices>` when tools exist.
 - Then it appends a `<must_principles>` block that tells the model to use native structured tool calls instead of writing fake tool calls in assistant text.
 - Current turn data is added as the user message, not merged into the system prompt.
+- For multimodal user turns, prefer `message: UserChatMessage` and construct content with `UserChatMessage.multimodal("text", ImgUrl(...), ImgPath(...))`. This keeps `llm_chat` as an Agent abstraction over one explicit user message instead of many loosely named image parameters.
 
 Write `llm_chat` docstrings as stable assistant policy and long-lived behavior. Put current task content in the function call arguments, not in the docstring.
 

--- a/skills/simplellmfunc/examples/README.md
+++ b/skills/simplellmfunc/examples/README.md
@@ -41,6 +41,7 @@ These are copied from the repo's main `examples/` directory to ground the skill 
 - `response_api_example.py`
 - `tui_chat_example.py`
 - `pyrepl_example.py`
+- `pyrepl_seaborn_multimodal_images.py`
 - `event_stream_chatbot.py`
 - `custom_tool_event_example.py`
 - `agent_as_tool_example.py`

--- a/skills/simplellmfunc/reference/decorators-and-tools.md
+++ b/skills/simplellmfunc/reference/decorators-and-tools.md
@@ -7,6 +7,7 @@ Use `@llm_function` for one-shot typed tasks. It returns an `LLMFunction` callab
 Best practices:
 
 - Keep the signature narrow and explicit.
+- For image input, declare explicit `ImgUrl` / `ImgPath` parameters or typed lists such as `list[ImgUrl]`. This is the correct multimodal style for `llm_function`.
 - Use a typed return value instead of asking the model for hand-written JSON.
 - Use `_template_params` only when one prompt pattern truly needs runtime role/style slots.
 - Add a toolkit only for real external capability, not for tasks the model can do unaided.
@@ -19,6 +20,7 @@ Best practices:
 
 - Use `stream=True` for chat UIs or incremental feedback.
 - Name the history parameter `history` or `chat_history`.
+- For multimodal input, use exactly one canonical `message: UserChatMessage` parameter and construct turns with `UserChatMessage.multimodal(...)`.
 - Keep `history` outside the function and feed it back in on the next turn.
 - Use `strict_signature=True` when you want a stable agent signature for self-reference or fork-heavy flows.
 - Set an explicit `max_tool_calls` only if you want a hard loop cap.

--- a/skills/simplellmfunc/reference/decorators-and-tools.md
+++ b/skills/simplellmfunc/reference/decorators-and-tools.md
@@ -34,6 +34,7 @@ Best practices:
 - The function must be `async def`.
 - Write a good docstring `Args:` section because parameter descriptions are extracted from it.
 - Keep tool outputs concise unless the full payload is truly required.
+- For multimodal outputs, return `ImgPath`, `ImgUrl`, `list[ImgPath | ImgUrl]`, `(text, ImgPath | ImgUrl)`, or `(text, list[ImgPath | ImgUrl])`.
 - Use `best_practices=[...]` when the model needs durable guidance about how to use the tool.
 - Use `too_long_to_file=True` for tools that may return massive text, such as code execution or large search results; the framework keeps roughly the first 20000 tokens in-chat and writes the full text to a temp file.
 

--- a/skills/simplellmfunc/reference/docs-source/detailed_guide/tool.md
+++ b/skills/simplellmfunc/reference/docs-source/detailed_guide/tool.md
@@ -35,7 +35,9 @@ SimpleLLMFunc 的工具系统为大语言模型提供了调用外部函数和 AP
 #### 多模态返回类型
 - **图片URL (`ImgUrl`)**: 返回网络图片链接，LLM 可以"看到"图片内容
 - **本地图片 (`ImgPath`)**: 返回本地图片文件路径，自动转换为 base64 格式
+- **多张图片 (`List[ImgPath | ImgUrl]`)**: 同一次工具调用返回多张图片
 - **文本+图片组合 (`Tuple[str, ImgUrl]` 或 `Tuple[str, ImgPath]`)**: 同时返回文本说明和图片
+- **文本+多图组合 (`Tuple[str, List[ImgPath | ImgUrl]]`)**: 同时返回文本说明和多张图片
 
 #### 返回类型示例
 
@@ -94,6 +96,12 @@ async def analyze_image(image_path: str) -> Tuple[str, ImgPath]:
     analysis_text = "检测到3个对象：2个人、1辆汽车"
     annotated_image = ImgPath("/path/to/annotated_image.png")
     return (analysis_text, annotated_image)
+
+# 5. 多模态返回 - 文本+多张图片
+@tool(name="compare_images", description="返回两张图片用于对比")
+async def compare_images(left_path: str, right_path: str) -> Tuple[str, List[ImgPath]]:
+    """返回对比说明和两张图片"""
+    return "请对比这两张图片", [ImgPath(left_path), ImgPath(right_path)]
 ```
 
 #### 返回类型处理机制
@@ -102,7 +110,7 @@ async def analyze_image(image_path: str) -> Tuple[str, ImgPath]:
 2. **图片类型**: 
    - `ImgUrl`: 直接使用网络 URL
    - `ImgPath`: 自动转换为 base64 编码的 data URL
-3. **组合类型**: 将文本和图片组合成多模态消息，LLM 可以同时看到文本说明和图片内容
+3. **组合类型**: 将文本和图片组合成多模态消息，LLM 可以同时看到文本说明和一张或多张图片内容
 4. **错误处理**: 不支持的返回类型会自动转换为字符串格式
 
 **多模态返回的特殊处理**：
@@ -115,6 +123,7 @@ async def analyze_image(image_path: str) -> Tuple[str, ImgPath]:
 - 确保本地图片文件路径存在且可读
 - 网络图片 URL 应该是公开可访问的
 - 组合类型的元组必须是 `(str, ImgPath)` 或 `(str, ImgUrl)` 格式, 不能交换`str`和`ImgPath`/`ImgUrl`的顺序
+- 多图组合类型必须是 `(str, list[ImgPath | ImgUrl])`，图片列表不能为空
 - 避免返回过大的数据结构，以免影响 LLM 处理效率
 
 ### 长文本截断功能
@@ -535,6 +544,20 @@ async def create_data_visualization(dataset: Dict[str, Any]) -> Tuple[str, ImgUr
     visualization_url = ImgUrl("https://example.com/visualizations/chart_12345.png")
     
     return (description.strip(), visualization_url)
+
+@tool(name="compare_generated_charts", description="生成并返回多个图表")
+async def compare_generated_charts(dataset: Dict[str, Any]) -> Tuple[str, List[ImgPath]]:
+    """
+    生成多个图表并一次返回给模型比较
+
+    Args:
+        dataset: 包含数据和配置的字典
+
+    Returns:
+        比较说明和多张本地图表图片
+    """
+    chart_paths = ["/tmp/chart_a.png", "/tmp/chart_b.png"]
+    return "请比较这两张图表的趋势差异", [ImgPath(path) for path in chart_paths]
 ```
 
 ### 继承方式示例

--- a/skills/simplellmfunc/reference/docs-source/examples.md
+++ b/skills/simplellmfunc/reference/docs-source/examples.md
@@ -295,6 +295,7 @@ poetry run python examples/llm_function_token_usage.py
 
 ### 工具调用
 - **内置 REPL 工具调用**: 见 [pyrepl_example.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/pyrepl_example.py)
+- **PyRepl 图片产物返回**: 见 [pyrepl_seaborn_multimodal_images.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/pyrepl_seaborn_multimodal_images.py)
 - **多工具并行调用**: 见 [parallel_toolcall_example.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/parallel_toolcall_example.py)
 - **Agent as a Tool**: 见 [agent_as_tool_example.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/agent_as_tool_example.py)
 
@@ -306,6 +307,7 @@ poetry run python examples/llm_function_token_usage.py
 
 ### 多模态处理
 - **图片分析**: 见 [multi_modality_toolcall.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/multi_modality_toolcall.py)
+- **多图工具返回**: 见 [pyrepl_seaborn_multimodal_images.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/pyrepl_seaborn_multimodal_images.py)
 - **混合输入输出**: 见 [multi_modality_toolcall.py](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/examples/multi_modality_toolcall.py)
 
 ## 快速运行示例

--- a/skills/simplellmfunc/reference/docs-source/pyrepl.md
+++ b/skills/simplellmfunc/reference/docs-source/pyrepl.md
@@ -7,6 +7,7 @@ SimpleLLMFunc 提供内置的 PyRepl 支持，允许 LLM 在一个连续上下�
 - **IPython 子进程后端**：每个 `PyRepl` 实例对应一个独立子进程，内部运行 `IPython InteractiveShell`
 - **连续上下文**：变量在多次调用间持久化，LLM 可以分步执行任务
 - **实时流式输出**：通过 `event_emitter` 实时获取 stdout/stderr 输出
+- **图片产物返回**：`display(Image(...))` 或最后表达式产生的图片会被捕获为多模态工具返回
 - **异步不阻塞**：代码执行在独立线程运行，不阻塞主事件循环（适合 TUI/流式 UI）
 - **Session 隔离**：不同的 PyRepl 实例相互独立，互不影响
 - **完整工具集**：提供 execute_code、reset_repl 等工具
@@ -98,11 +99,46 @@ async def chat2(message: str, history=None):
     "stdout": str,                # 标准输出
     "stderr": str,                # 标准错误
     "return_value": Any,          # 最后表达式的值
+    "artifacts": list[dict],      # 图片等执行产物（execute_code 工具会转成多模态返回）
     "error": str | None,          # 错误信息（可直接定位到输入代码行）
     "error_details": dict | None, # 结构化错误详情（行号/列号/代码片段/指针等）
     "execution_time_ms": float    # 执行时间（毫秒）
 }
 ```
+
+### 图片输出
+
+当代码输出图片时，作为 Agent 工具使用的 `execute_code` 会返回多模态工具结果：模型会看到执行摘要，也会看到图片内容。
+
+推荐写法：
+
+```python
+from IPython.display import Image, display
+
+display(Image(filename="chart.png"))
+```
+
+或把图片对象作为最后表达式：
+
+```python
+from IPython.display import Image
+
+Image(filename="chart.png")
+```
+
+生成图表时，保存文件并显式返回 `ImgPath` 最清晰：
+
+```python
+import matplotlib.pyplot as plt
+from SimpleLLMFunc.type import ImgPath
+
+plt.plot([1, 2, 3])
+path = "chart.png"
+plt.savefig(path)
+ImgPath(path)
+```
+
+直接调用 `await repl.execute(...)` 时，图片会出现在返回 dict 的 `artifacts` 列表中；经由 `execute_code` 工具调用时，框架会自动把 artifact 转成 `ImgPath` / `ImgUrl` 多模态返回。
 
 ### 错误定位增强
 
@@ -558,5 +594,6 @@ print(result)  # "REPL 已重置，所有变量已清除"
 ## Related Links
 
 - Example: `examples/pyrepl_example.py`
+- Image artifact example: `examples/pyrepl_seaborn_multimodal_images.py`
 - Local runtime memory demo: `examples/runtime_primitives_basic_example.py`
 - General TUI agent demo: `examples/tui_general_agent_example.py` (workspace scoped to `./sandbox`)

--- a/skills/simplellmfunc/reference/philosophy-and-concepts.md
+++ b/skills/simplellmfunc/reference/philosophy-and-concepts.md
@@ -49,7 +49,7 @@ There is one correct shape per surface:
 
 - `@llm_function`: use explicit `ImgUrl` / `ImgPath` typed parameters, matching the normal Python-function mental model.
 - `@llm_chat`: use one canonical `message: UserChatMessage` object for multimodal user input, because a chat agent consumes one user turn.
-- `@tool`: use explicit multimodal parameter or return types such as `ImgPath`, `ImgUrl`, or supported tuples/lists.
+- `@tool`: use explicit multimodal parameter or return types such as `ImgPath`, `ImgUrl`, `list[ImgPath | ImgUrl]`, or supported tuples/lists.
 
 Prefer these typed multimodal values instead of ad hoc strings that happen to contain paths or URLs.
 

--- a/skills/simplellmfunc/reference/philosophy-and-concepts.md
+++ b/skills/simplellmfunc/reference/philosophy-and-concepts.md
@@ -43,8 +43,15 @@ SimpleLLMFunc supports multimodal values through:
 - `Text`
 - `ImgPath`
 - `ImgUrl`
+- `UserChatMessage` for chat-agent user turns
 
-You can use them in function parameters, tool parameters, and some tool return shapes. For user-facing application code, prefer explicit multimodal types instead of ad hoc strings that happen to contain paths or URLs.
+There is one correct shape per surface:
+
+- `@llm_function`: use explicit `ImgUrl` / `ImgPath` typed parameters, matching the normal Python-function mental model.
+- `@llm_chat`: use one canonical `message: UserChatMessage` object for multimodal user input, because a chat agent consumes one user turn.
+- `@tool`: use explicit multimodal parameter or return types such as `ImgPath`, `ImgUrl`, or supported tuples/lists.
+
+Prefer these typed multimodal values instead of ad hoc strings that happen to contain paths or URLs.
 
 ## History and state
 

--- a/skills/simplellmfunc/reference/pyrepl-runtime.md
+++ b/skills/simplellmfunc/reference/pyrepl-runtime.md
@@ -6,6 +6,7 @@ Use `PyRepl` when the model needs:
 
 - persistent Python execution across turns
 - runtime primitive discovery through `runtime.*`
+- image-producing code whose plots or `IPython.display.Image` results should be returned to the model as multimodal tool output
 - durable self-reference context
 - a forkable execution environment for sub-agents or parallel work
 

--- a/spec/project-map.md
+++ b/spec/project-map.md
@@ -317,10 +317,11 @@ SimpleLLMFunc/
 
 **子模块**:
 
-- `message.py`: 消息类型
+- `message.py`: 消息类型与 OpenAI-compatible content part 类型
+- `chat_input.py`: `UserChatMessage` canonical chat user input object
 - `tool_call.py`: 工具调用类型
 - `llm.py`: LLM 相关类型
-- `multimodal.py`: 多模态类型
+- `multimodal.py`: 多模态基础类型（`Text` / `ImgUrl` / `ImgPath`）
 - `hooks.py`: 事件相关类型
 
 ### logger 模块

--- a/tests/test_base/test_react_core_scheduler.py
+++ b/tests/test_base/test_react_core_scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -106,6 +105,56 @@ async def test_schedule_tool_batch_maps_multimodal_messages_to_user_message_muta
     assert isinstance(result, ToolSchedulerResult)
     assert isinstance(result.mutations[0], MultimodalToolResultMutation)
     assert result.mutations[0].user_messages[0]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_schedule_tool_batch_sets_multimodal_tool_end_result() -> None:
+    async def fake_execute_single_tool_call_result(tool_call, tool_map, event_emitter=None, trace_context=None):
+        _ = (tool_map, event_emitter, trace_context)
+        return ExecutedToolCallResult(
+            tool_call=tool_call,
+            tool_call_id=tool_call["id"],
+            tool_name=tool_call["function"]["name"],
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "image summary"},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+                    ],
+                }
+            ],
+            result=("image summary", ["image-placeholder"]),
+            is_multimodal=True,
+        )
+
+    tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "test_tool", "arguments": "{}"},
+    }
+
+    outputs = []
+    with patch(
+        "SimpleLLMFunc.base.tool_scheduler.execute_single_tool_call_result",
+        new=fake_execute_single_tool_call_result,
+    ):
+        async for output in schedule_tool_batch(
+            tool_calls=[tool_call],
+            messages=[{"role": "user", "content": "hello"}],
+            tool_map={"test_tool": AsyncMock(return_value="ok")},
+            trace_id="trace-1",
+            func_name="test_func",
+            iteration=1,
+        ):
+            outputs.append(output)
+
+    tool_end = next(
+        output.event
+        for output in outputs
+        if isinstance(output, EventYield) and isinstance(output.event, ToolCallEndEvent)
+    )
+    assert tool_end.result == ("image summary", ["image-placeholder"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_base/test_tool_call/test_execution.py
+++ b/tests/test_base/test_tool_call/test_execution.py
@@ -125,6 +125,35 @@ class TestExecuteSingleToolCallResult:
         assert result.messages[0]["role"] == "user"
 
     @pytest.mark.asyncio
+    async def test_execute_tuple_with_multiple_images_result(
+        self,
+        img_path: ImgPath,
+        img_url: ImgUrl,
+    ) -> None:
+        tool_call = {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "test_tool", "arguments": "{}"},
+        }
+        tool_map = {"test_tool": AsyncMock(return_value=("text", [img_url, img_path]))}
+
+        result = await execute_single_tool_call_result(tool_call, tool_map)
+
+        assert result.is_multimodal is True
+        assert len(result.messages) == 1
+        assert result.messages[0]["role"] == "user"
+        content = result.messages[0]["content"]
+        assert isinstance(content, list)
+        assert content[0] == {
+            "type": "text",
+            "text": "This is images and description returned by tool 'test_tool': text",
+        }
+        image_parts = [part for part in content if part.get("type") == "image_url"]
+        assert len(image_parts) == 2
+        assert image_parts[0]["image_url"]["url"] == img_url.url
+        assert image_parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    @pytest.mark.asyncio
     async def test_execute_tool_not_found(self) -> None:
         tool_call = {
             "id": "call_123",

--- a/tests/test_base/test_tool_call/test_validation.py
+++ b/tests/test_base/test_tool_call/test_validation.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
-import pytest
-
 from SimpleLLMFunc.base.tool_call.validation import (
     is_valid_tool_result,
     serialize_tool_output_for_langfuse,
@@ -39,6 +35,15 @@ class TestIsValidToolResult:
     def test_valid_tuple_with_image(self, img_url: ImgUrl) -> None:
         """Test tuple with image validation."""
         result = ("text", img_url)
+        assert is_valid_tool_result(result) is True
+
+    def test_valid_tuple_with_multiple_images(
+        self,
+        img_path: ImgPath,
+        img_url: ImgUrl,
+    ) -> None:
+        """Test tuple with multiple images validation."""
+        result = ("text", [img_url, img_path])
         assert is_valid_tool_result(result) is True
 
     def test_invalid_tuple(self) -> None:
@@ -87,6 +92,17 @@ class TestSerializeToolOutputForLangfuse:
         assert result["text"] == "text"
         assert "image" in result
 
+    def test_serialize_tuple_with_multiple_images(
+        self,
+        img_path: ImgPath,
+        img_url: ImgUrl,
+    ) -> None:
+        """Test serializing tuple with multiple images."""
+        result = serialize_tool_output_for_langfuse(("text", [img_url, img_path]))
+        assert result["type"] == "text_with_images"
+        assert result["text"] == "text"
+        assert len(result["images"]) == 2
+
     def test_serialize_dict(self) -> None:
         """Test serializing dict."""
         data = {"key": "value", "number": 123}
@@ -108,4 +124,3 @@ class TestSerializeToolOutputForLangfuse:
         obj = NonSerializable()
         result = serialize_tool_output_for_langfuse(obj)
         assert result == "non-serializable"
-

--- a/tests/test_builtin/test_pyrepl.py
+++ b/tests/test_builtin/test_pyrepl.py
@@ -408,6 +408,32 @@ class TestPyReplToolsetOutput:
         assert "stdout:" in result
         assert "hello" in result
 
+    @pytest.mark.asyncio
+    async def test_execute_tool_returns_multimodal_output_for_image_artifact(self):
+        from SimpleLLMFunc.builtin import PyRepl
+        from SimpleLLMFunc.type import ImgPath
+
+        repl = PyRepl()
+        execute_tool = next(
+            tool for tool in repl.toolset if tool.name == "execute_code"
+        )
+
+        result = await execute_tool.run(
+            """
+from IPython.display import Image
+Image(data=b'fake image data', format='png')
+"""
+        )
+
+        assert isinstance(result, tuple)
+        summary, images = result
+        assert isinstance(summary, str)
+        assert "Execution succeeded" in summary
+        assert "image artifact" in summary
+        assert isinstance(images, list)
+        assert len(images) == 1
+        assert isinstance(images[0], ImgPath)
+
 
 class TestPyReplExecute:
     """Test PyRepl execute functionality."""
@@ -466,6 +492,66 @@ class TestPyReplExecute:
 
         assert result["success"] is True
         assert result["return_value"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_execute_expression_image_result_records_artifact(self):
+        """Expression display images should be returned as structured artifacts."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        repl = PyRepl()
+        result = await repl.execute(
+            """
+from IPython.display import Image
+Image(data=b'fake image data', format='png')
+"""
+        )
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        assert result["return_value"] is None
+        artifacts = result["artifacts"]
+        assert len(artifacts) == 1
+        assert artifacts[0]["type"] == "image"
+        assert artifacts[0]["mime_type"] == "image/png"
+        assert Path(artifacts[0]["path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_execute_display_image_call_records_artifact(self):
+        """Explicit display(Image(...)) calls should be returned as artifacts."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        repl = PyRepl()
+        result = await repl.execute(
+            """
+from IPython.display import Image, display
+display(Image(data=b'fake image data', format='png'))
+"""
+        )
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        artifacts = result["artifacts"]
+        assert len(artifacts) == 1
+        assert artifacts[0]["type"] == "image"
+        assert artifacts[0]["mime_type"] == "image/png"
+        assert Path(artifacts[0]["path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_execute_display_mixed_content_preserves_text_output(self):
+        """display(Image(...), text) should capture images and keep text display."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        repl = PyRepl()
+        result = await repl.execute(
+            """
+from IPython.display import Image, display
+display(Image(data=b'fake image data', format='png'), "keep text")
+"""
+        )
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        assert "keep text" in result["stdout"]
+        artifacts = result["artifacts"]
+        assert len(artifacts) == 1
+        assert artifacts[0]["type"] == "image"
 
     @pytest.mark.asyncio
     async def test_execute_runtime_error_includes_structured_details(self):
@@ -1167,7 +1253,6 @@ class TestPyReplRuntimePrimitives:
     def test_registered_primitive_specs_match_handler_signatures(self):
         """Declared primitive parameter kinds should match handler signatures."""
         from SimpleLLMFunc.builtin import PyRepl
-        from SimpleLLMFunc.runtime.selfref import SelfReference
 
         kind_map = {
             inspect.Parameter.POSITIONAL_ONLY: "positional_only",

--- a/tests/test_interface/test_openai_responses_compatible.py
+++ b/tests/test_interface/test_openai_responses_compatible.py
@@ -378,6 +378,49 @@ async def test_chat_maps_system_messages_to_instructions() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_maps_multimodal_user_content_to_responses_input() -> None:
+    llm = _build_llm()
+    response = _make_text_response("ok")
+    create_mock = AsyncMock(return_value=response)
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=create_mock))
+    llm._get_or_create_client = AsyncMock(return_value=fake_client)
+
+    await llm.chat(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://example.com/cat.png",
+                            "detail": "high",
+                        },
+                    },
+                ],
+            }
+        ]
+    )
+
+    request_input = create_mock.await_args.kwargs["input"]
+    assert request_input == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What is in this image?"},
+                {
+                    "type": "input_image",
+                    "image_url": "https://example.com/cat.png",
+                    "detail": "high",
+                },
+            ],
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_chat_maps_assistant_tool_calls_to_function_call_items() -> None:
     llm = _build_llm()
     response = _make_text_response("ok")

--- a/tests/test_llm_chat_decorator.py
+++ b/tests/test_llm_chat_decorator.py
@@ -43,6 +43,7 @@ from SimpleLLMFunc.hooks.stream import (
     EventOrigin,
     EventYield,
     ReactOutput,
+    ResponseYield,
     is_response_yield,
 )
 from SimpleLLMFunc.llm_decorator.llm_chat_decorator import (
@@ -56,6 +57,7 @@ from SimpleLLMFunc.observability.langfuse_client import (
     set_langfuse_trace_context,
 )
 from SimpleLLMFunc.tool import Tool
+from SimpleLLMFunc.type import UserChatMessage, ImgUrl
 
 
 _MUST_PROMPT_BLOCK = "<must_principles>"
@@ -367,6 +369,77 @@ def test_llm_chat_strict_signature_enforces_history_message_shape() -> None:
         """test agent"""
 
     assert callable(agent)
+
+
+
+def test_llm_chat_strict_signature_accepts_chat_user_message_shape() -> None:
+    mock_llm = MagicMock()
+    mock_llm.model_name = "test-model"
+
+    @llm_chat(llm_interface=mock_llm, strict_signature=True)
+    async def agent(history, message: UserChatMessage, _template_params=None):
+        """test agent"""
+
+    assert callable(agent)
+
+
+
+@pytest.mark.asyncio
+async def test_llm_chat_accepts_explicit_multimodal_user_message() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_react_loop(*args: Any, **kwargs: Any):
+        _ = args
+        captured["messages"] = kwargs["messages"]
+        captured["user_task_prompt"] = kwargs["user_task_prompt"]
+        yield ResponseYield(
+            type="response",
+            response="ok",
+            messages=kwargs["messages"],
+        )
+
+    mock_llm = MagicMock()
+    mock_llm.model_name = "test-model"
+
+    with (
+        patch(
+            "SimpleLLMFunc.llm_decorator.llm_chat_decorator.ReAct_loop",
+            new=fake_react_loop,
+        ),
+        patch(
+            "SimpleLLMFunc.llm_decorator.llm_chat_decorator.langfuse_client.start_as_current_observation",
+            return_value=_DummyObservation(),
+        ),
+    ):
+
+        @llm_chat(llm_interface=mock_llm)
+        async def agent(message: UserChatMessage, history=None):
+            """vision agent"""
+
+        user_message = UserChatMessage.multimodal(
+            "What is in this image?",
+            ImgUrl("https://example.com/cat.png", detail="high"),
+        )
+
+        outputs = []
+        async for output in agent(user_message, history=[]):
+            outputs.append(output)
+
+    assert outputs
+    user_message_payload = captured["messages"][-1]
+    assert user_message_payload["role"] == "user"
+    assert user_message_payload["content"] == [
+        {"type": "text", "text": "What is in this image?"},
+        {
+            "type": "image_url",
+            "image_url": {
+                "url": "https://example.com/cat.png",
+                "detail": "high",
+            },
+        },
+    ]
+    assert '"role": "user"' in captured["user_task_prompt"]
+    assert "https://example.com/cat.png" in captured["user_task_prompt"]
 
 
 def test_llm_chat_strict_signature_rejects_non_canonical_shapes() -> None:

--- a/tests/test_llm_function_decorator.py
+++ b/tests/test_llm_function_decorator.py
@@ -11,6 +11,7 @@ import pytest
 
 from SimpleLLMFunc import LLMFunction, llm_function
 from SimpleLLMFunc.hooks.stream import ResponseYield
+from SimpleLLMFunc.type import ImgUrl
 from SimpleLLMFunc.observability.langfuse_client import (
     langfuse_client as shared_langfuse_client,
 )
@@ -198,6 +199,60 @@ async def test_llm_function_passes_none_max_tool_calls_to_react_loop() -> None:
     assert inspect.iscoroutinefunction(summarize)
     assert inspect.signature(summarize) == inspect.signature(summarize.__wrapped__)
     mock_parse.assert_called_once_with(raw_response, str)
+
+
+@pytest.mark.asyncio
+async def test_llm_function_builds_multimodal_input_from_typed_image_params() -> None:
+    captured: dict[str, Any] = {}
+    raw_response = object()
+
+    async def fake_react_loop(*args: Any, **kwargs: Any):
+        _ = args
+        captured["messages"] = kwargs["messages"]
+        captured["user_task_prompt"] = kwargs["user_task_prompt"]
+        yield ResponseYield(type="response", response=raw_response, messages=[])
+
+    mock_llm = MagicMock()
+    mock_llm.model_name = "test-model"
+
+    with (
+        patch(
+            "SimpleLLMFunc.llm_decorator.llm_function_decorator.ReAct_loop",
+            new=fake_react_loop,
+        ),
+        patch(
+            "SimpleLLMFunc.llm_decorator.llm_function_decorator.process_response",
+            return_value="parsed-result",
+        ),
+        patch(
+            "SimpleLLMFunc.llm_decorator.llm_function_decorator.langfuse_client.start_as_current_observation",
+            return_value=_DummyObservation(),
+        ),
+    ):
+
+        @llm_function(llm_interface=mock_llm)
+        async def analyze_image(instruction: str, image: ImgUrl) -> str:
+            """Analyze the provided image."""
+
+        result = await analyze_image(
+            "describe it",
+            ImgUrl("https://example.com/image.png", detail="high"),
+        )
+
+    assert result == "parsed-result"
+    user_message = captured["messages"][1]
+    assert user_message["role"] == "user"
+    assert user_message["content"] == [
+        {"type": "text", "text": "instruction: describe it"},
+        {
+            "type": "image_url",
+            "image_url": {
+                "url": "https://example.com/image.png",
+                "detail": "high",
+            },
+        },
+    ]
+    assert '"image": "https://example.com/image.png"' in captured["user_task_prompt"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `UserChatMessage` as the canonical multimodal user-message object for `llm_chat`.
- Keep `llm_function` multimodal input function-like through explicit `ImgUrl` / `ImgPath` typed parameters.
- Update README, Mintlify docs, specs, packaged skills, and changelog with the one-good-way input policy.
- Add regression coverage for typed `llm_function` image input and `llm_chat` `UserChatMessage` input.

## Validation
- `poetry run pytest tests/test_llm_function_decorator.py tests/test_llm_chat_decorator.py tests/test_stage2_unified_invocation.py tests/test_base/test_react_core_loop.py -q`
- `poetry run pytest -q` (`664 passed`)
