### PR TITLE
Release SimpleLLMFunc 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.8.3 (2026-05-27) - Dependency Constraint Relaxation
+
+### 🔧 Improvements
+
+- Relaxed runtime, development, and build-system package dependency constraints to use lower-bound-only `>=...` specifiers instead of Poetry caret constraints, fixed pins, or explicit upper bounds.
+- Dropped the tracked `uv.lock` file because the project release workflow no longer supports uv lock synchronization.
+- Regenerated `poetry.lock` after the constraint cleanup; `rich` now resolves to `15.0.0`.
+
+### 🧪 Testing
+
+- Verified the Poetry metadata and sync workflow with `poetry check`, `poetry lock`, and `poetry sync`.
+- Re-ran TUI dependency regression coverage: `19 passed`.
+
 ## 0.8.2 (2026-05-27) - Multimodal Inputs and PyRepl Image Outputs
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/pulls)
 
-### Update Notes (0.8.2)
+### Update Notes (0.8.3)
 
-**Multimodal release**: `llm_function` now accepts typed image inputs (`ImgPath`, `ImgUrl`, lists, and unions), while `llm_chat` gets the canonical `UserChatMessage.multimodal(...)` helper for mixed text/image user turns. **PyRepl** now captures image artifacts from `display(Image(...))`, image-rich last expressions, and `ImgPath` / `ImgUrl` results, then returns them through `execute_code` as multimodal tool output. Tool results also support multiple images via `list[ImgPath | ImgUrl]` and `(text, list[ImgPath | ImgUrl])`. See **[CHANGELOG](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)** for details.
+**Dependency constraint cleanup**: runtime, development, and build-system package dependencies now use lower-bound-only `>=...` specifiers instead of Poetry caret constraints, fixed pins, or explicit package upper bounds. The Poetry lockfile has been regenerated for the new constraints, and the unused `uv.lock` file has been removed from the release workflow. See **[CHANGELOG](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)** for details.
 
 ### Documentation
 
@@ -655,7 +655,7 @@ LANGFUSE_EXPORT_ALL_SPANS=true
   month = {February},
   title = {{SimpleLLMFunc: A New Approach to Build LLM Applications}},
   url = {https://github.com/NiJingzhe/SimpleLLMFunc},
-  version = {0.8.2},
+  version = {0.8.3},
   year = {2026}
 }
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -21,9 +21,9 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/pulls)
 
-### 更新说明 (0.8.2)
+### 更新说明 (0.8.3)
 
-**多模态版本**：`llm_function` 现在支持 typed image inputs（`ImgPath`、`ImgUrl`、列表和 union），`llm_chat` 新增 canonical `UserChatMessage.multimodal(...)` helper，用于混合文本/图片用户输入。**PyRepl** 现在会捕获 `display(Image(...))`、图片型最后表达式，以及 `ImgPath` / `ImgUrl` 结果产生的图片 artifact，并通过 `execute_code` 作为多模态工具输出返回。工具结果也支持通过 `list[ImgPath | ImgUrl]` 和 `(text, list[ImgPath | ImgUrl])` 一次返回多张图片。详情见 **[更新日志](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)**。
+**依赖约束清理**：runtime、development 和 build-system 包依赖现在统一使用无上限的 `>=...` 约束，不再使用 Poetry caret、固定版本或显式包版本上限。Poetry lockfile 已按新约束重新生成，未继续支持的 `uv.lock` 也已从发布流程中移除。详情见 **[更新日志](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)**。
 
 ### 文档
 
@@ -654,7 +654,7 @@ LANGFUSE_EXPORT_ALL_SPANS=true
   month = {February},
   title = {{SimpleLLMFunc: A New Approach to Build LLM Applications}},
   url = {https://github.com/NiJingzhe/SimpleLLMFunc},
-  version = {0.8.2},
+  version = {0.8.3},
   year = {2026}
 }
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -2290,14 +2290,14 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 groups = ["main", "dev"]
 files = [
-    {file = "rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d"},
-    {file = "rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"},
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
 ]
 
 [package.dependencies]
@@ -2999,4 +2999,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "777800f36d742cb2fe00c7da17aedb0d706848c7b5ffd5ce28e9c67856889b1f"
+content-hash = "b6537c43222be7bedbd028474ca10203c95f9b194b4654c6698a5ae99c6139cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SimpleLLMFunc"
-version = "0.8.2"
+version = "0.8.3"
 description = "A lightweight yet complete LLM/Agent application development framework. Provides decorators that use function docstrings as prompts, requiring no function body implementation while allowing you to benefit from function definitions and type annotations for higher development efficiency. Seamlessly integrate LLM capabilities into any Python project with minimal code."
 authors = ["Ni Jingzhe <nijingzhe@zju.edu.cn>"]
 readme = "README.md"
@@ -15,29 +15,29 @@ simplellmfunc-skill = "SimpleLLMFunc.skills_cli:main"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-openai = ">=2.0.0,<3.0.0"
-pydantic = ">=2.11.5,<3.0.0"
-pydantic-settings = ">=2.9.1,<3.0.0"
-httpx = { extras = ["socks"], version = "^0.28.1" }
-rich = "^14.0.0"
-textual = "8.2.2"
-langfuse = "^4.0.0"
-ipython = "^9.0.0"
+openai = ">=2.0.0"
+pydantic = ">=2.11.5"
+pydantic-settings = ">=2.9.1"
+httpx = { extras = ["socks"], version = ">=0.28.1" }
+rich = ">=15.0"
+textual = ">=8.2.2"
+langfuse = ">=4.0.0"
+ipython = ">=9.0.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.4.0"
-pytest-mock = "^3.14.1"
-polib = "^1.2.0"
-types-polib = "^1.2.0.20250401"
-myst-parser = "^4.0.1"
-pytest-asyncio = "^1.3.0"
-roman-numerals-py = "^4.1.0"
-roman-numerals = "^4.1.0"
-textual-hmr = "^0.0.2"
-ruff = "^0.15.12"
-pyright = "^1.1.409"
-seaborn = "^0.13.2"
+pytest = ">=8.4.0"
+pytest-mock = ">=3.14.1"
+polib = ">=1.2.0"
+types-polib = ">=1.2.0.20250401"
+myst-parser = ">=4.0.1"
+pytest-asyncio = ">=1.3.0"
+roman-numerals-py = ">=4.1.0"
+roman-numerals = ">=4.1.0"
+textual-hmr = ">=0.0.2"
+ruff = ">=0.15.12"
+pyright = ">=1.1.409"
+seaborn = ">=0.13.2"
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/skills/simplellmfunc-developer/SKILL.md
+++ b/skills/simplellmfunc-developer/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Python 3.12+ repo with pytest, Poetry, Mintlify docs, and SimpleLLMFunc source tree available."
 metadata:
   project: SimpleLLMFunc
-  version: "0.8.2"
+  version: "0.8.3"
 ---
 
 # SimpleLLMFunc Framework Development

--- a/skills/simplellmfunc/SKILL.md
+++ b/skills/simplellmfunc/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Python 3.12+ repo with async execution and OpenAI-compatible chat endpoints or OpenAI Responses API endpoints configured through provider.json."
 metadata:
   project: SimpleLLMFunc
-  version: "0.8.2"
+  version: "0.8.3"
 ---
 
 # SimpleLLMFunc Usage

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- Relax runtime, dev, and build-system package dependency constraints to lower-bound-only specifiers
- Regenerate poetry.lock and remove uv.lock from the release workflow
- Update release metadata for 0.8.3

## Verification
- poetry lock
- poetry sync
- poetry check
- git diff --check
- poetry run pytest tests/test_utils/test_tui/test_core.py tests/test_tui_general_agent_example.py