### PR TITLE
Release SimpleLLMFunc 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 0.8.4 (2026-05-28) - PyRepl Terminal Isolation
+
+### 🔧 Improvements
+
+- Isolated PyRepl worker stdio at the file-descriptor level so fd `0` no longer inherits the host terminal and fd `1`/`2` are captured through worker-owned pipes.
+- Captured direct `os.write(...)`, C extension output, shell command output, and subprocess stdout/stderr into PyRepl stdout/stderr results instead of leaking to TUI hosts.
+- Detached the worker session on POSIX when possible to reduce access to the host controlling terminal.
+- Dropped late output from long-lived child processes after their originating execution finishes so it cannot contaminate later `execute_code` calls.
+
+### 🧪 Testing
+
+- Added regression coverage for isolated worker fds, direct fd writes, subprocess fd writes, non-duplicated Python `print()` output, and late child-process output.
+- Stabilized async timing tests that were too sensitive to full-suite scheduling load.
+- Verified the full Poetry test suite: `678 passed`.
+
 ## 0.8.3 (2026-05-27) - Dependency Constraint Relaxation
 
 ### 🔧 Improvements

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/pulls)
 
-### Update Notes (0.8.3)
+### Update Notes (0.8.4)
 
-**Dependency constraint cleanup**: runtime, development, and build-system package dependencies now use lower-bound-only `>=...` specifiers instead of Poetry caret constraints, fixed pins, or explicit package upper bounds. The Poetry lockfile has been regenerated for the new constraints, and the unused `uv.lock` file has been removed from the release workflow. See **[CHANGELOG](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)** for details.
+**PyRepl terminal isolation**: PyRepl worker processes now isolate fd `0`/`1`/`2` from host terminals, capture direct fd writes and subprocess stdout/stderr into tool output, and drop late child-process output so it cannot corrupt TUI hosts or contaminate later snippets. See **[CHANGELOG](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)** for details.
 
 ### Documentation
 
@@ -655,7 +655,7 @@ LANGFUSE_EXPORT_ALL_SPANS=true
   month = {February},
   title = {{SimpleLLMFunc: A New Approach to Build LLM Applications}},
   url = {https://github.com/NiJingzhe/SimpleLLMFunc},
-  version = {0.8.3},
+  version = {0.8.4},
   year = {2026}
 }
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -21,9 +21,9 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/NiJingzhe/SimpleLLMFunc/pulls)
 
-### 更新说明 (0.8.3)
+### 更新说明 (0.8.4)
 
-**依赖约束清理**：runtime、development 和 build-system 包依赖现在统一使用无上限的 `>=...` 约束，不再使用 Poetry caret、固定版本或显式包版本上限。Poetry lockfile 已按新约束重新生成，未继续支持的 `uv.lock` 也已从发布流程中移除。详情见 **[更新日志](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)**。
+**PyRepl 终端隔离**：PyRepl worker 现在会隔离宿主终端的 fd `0`/`1`/`2`，把直接 fd 写入和子进程 stdout/stderr 捕获到工具输出中，并丢弃长活子进程的迟到输出，避免污染 TUI 宿主或后续代码片段。详情见 **[更新日志](https://github.com/NiJingzhe/SimpleLLMFunc/blob/master/CHANGELOG.md)**。
 
 ### 文档
 
@@ -654,7 +654,7 @@ LANGFUSE_EXPORT_ALL_SPANS=true
   month = {February},
   title = {{SimpleLLMFunc: A New Approach to Build LLM Applications}},
   url = {https://github.com/NiJingzhe/SimpleLLMFunc},
-  version = {0.8.3},
+  version = {0.8.4},
   year = {2026}
 }
 ```

--- a/SimpleLLMFunc/builtin/pyrepl_worker.py
+++ b/SimpleLLMFunc/builtin/pyrepl_worker.py
@@ -15,6 +15,7 @@ import os
 import queue
 import sys
 import tempfile
+import threading
 import time
 import traceback
 import uuid
@@ -73,16 +74,322 @@ class _LineCapture(io.TextIOBase):
             self._buffer = ""
 
 
+class _FdCapture:
+    """Worker-local fd capture for direct writes and child process output."""
+
+    _FLUSH_PREFIX_BASE = b"\x00SLF_FD_FLUSH"
+    _FLUSH_TOKEN_BYTES = 8
+
+    def __init__(
+        self,
+        emit_stdout: Callable[[str, str], None],
+        emit_stderr: Callable[[str, str], None],
+    ) -> None:
+        self._emit_stdout = emit_stdout
+        self._emit_stderr = emit_stderr
+        self._flush_lock = threading.Lock()
+        self._flush_counter = 0
+        self._flush_prefix = self._FLUSH_PREFIX_BASE + uuid.uuid4().bytes
+        self._flush_events: dict[
+            bytes,
+            tuple[threading.Event, Optional[threading.Event]],
+        ] = {}
+        self._stdout_flush_fd: Optional[int] = None
+        self._stderr_flush_fd: Optional[int] = None
+        self._stdout_finished: Optional[threading.Event] = None
+        self._stderr_finished: Optional[threading.Event] = None
+
+    def install(self) -> None:
+        stdin_fd = os.open(os.devnull, os.O_RDONLY)
+        try:
+            os.dup2(stdin_fd, 0, inheritable=True)
+            os.set_inheritable(0, True)
+        finally:
+            if stdin_fd != 0:
+                os.close(stdin_fd)
+
+        self._ensure_fd_open(1, os.O_WRONLY)
+        self._ensure_fd_open(2, os.O_WRONLY)
+
+        self._redirect_fd_to_devnull(1)
+        self._redirect_fd_to_devnull(2)
+
+    def begin_execution(self, exec_id: str) -> None:
+        self._stdout_flush_fd, self._stdout_finished = self._install_output_pipe(
+            fd=1,
+            exec_id=exec_id,
+            emit=self._emit_stdout,
+        )
+        self._stderr_flush_fd, self._stderr_finished = self._install_output_pipe(
+            fd=2,
+            exec_id=exec_id,
+            emit=self._emit_stderr,
+        )
+
+    def finish_execution(self, timeout_seconds: float = 1.0) -> None:
+        self.flush(
+            timeout_seconds=timeout_seconds,
+            stdout_finished=self._stdout_finished,
+            stderr_finished=self._stderr_finished,
+        )
+        self._redirect_fd_to_devnull(1)
+        self._redirect_fd_to_devnull(2)
+        self._close_flush_fds()
+        for event in (self._stdout_finished, self._stderr_finished):
+            if event is not None:
+                event.set()
+        self._stdout_finished = None
+        self._stderr_finished = None
+
+    def _install_output_pipe(
+        self,
+        *,
+        fd: int,
+        exec_id: str,
+        emit: Callable[[str, str], None],
+    ) -> tuple[int, threading.Event]:
+        stdout_read, stdout_write = os.pipe()
+        flush_fd = os.dup(stdout_write)
+        os.set_inheritable(flush_fd, False)
+        finished = threading.Event()
+
+        os.dup2(stdout_write, fd, inheritable=True)
+        os.set_inheritable(fd, True)
+
+        if stdout_write != fd:
+            os.close(stdout_write)
+
+        self._start_reader(stdout_read, exec_id, emit, finished)
+        return flush_fd, finished
+
+    def flush(
+        self,
+        timeout_seconds: float = 1.0,
+        *,
+        stdout_finished: Optional[threading.Event] = None,
+        stderr_finished: Optional[threading.Event] = None,
+    ) -> None:
+        stdout_event = self._write_flush_marker(
+            self._stdout_flush_fd,
+            finished=stdout_finished,
+        )
+        stderr_event = self._write_flush_marker(
+            self._stderr_flush_fd,
+            finished=stderr_finished,
+        )
+
+        deadline = time.monotonic() + timeout_seconds
+        for event in (stdout_event, stderr_event):
+            if event is None:
+                continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            event.wait(remaining)
+
+    def _write_flush_marker(
+        self,
+        fd: Optional[int],
+        *,
+        finished: Optional[threading.Event] = None,
+    ) -> Optional[threading.Event]:
+        if fd is None:
+            if finished is not None:
+                finished.set()
+            return None
+
+        with self._flush_lock:
+            self._flush_counter += 1
+            token = self._flush_counter.to_bytes(self._FLUSH_TOKEN_BYTES, "big")
+            event = threading.Event()
+            self._flush_events[token] = (event, finished)
+
+        try:
+            os.write(fd, self._flush_prefix + token)
+        except OSError:
+            with self._flush_lock:
+                self._flush_events.pop(token, None)
+            if finished is not None:
+                finished.set()
+            return None
+        return event
+
+    def _ack_flush_marker(self, token: bytes) -> None:
+        with self._flush_lock:
+            item = self._flush_events.pop(token, None)
+        if item is not None:
+            event, finished = item
+            if finished is not None:
+                finished.set()
+            event.set()
+
+    def _start_reader(
+        self,
+        fd: int,
+        exec_id: str,
+        emit: Callable[[str, str], None],
+        finished: threading.Event,
+    ) -> None:
+        thread = threading.Thread(
+            target=self._drain_fd,
+            args=(fd, exec_id, emit, finished),
+            daemon=True,
+        )
+        thread.start()
+
+    def _drain_fd(
+        self,
+        fd: int,
+        exec_id: str,
+        emit: Callable[[str, str], None],
+        finished: threading.Event,
+    ) -> None:
+        buffer = b""
+        marker_size = len(self._flush_prefix) + self._FLUSH_TOKEN_BYTES
+
+        try:
+            while True:
+                try:
+                    chunk = os.read(fd, 4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+
+                buffer += chunk
+                while True:
+                    marker_index = buffer.find(self._flush_prefix)
+                    if marker_index < 0:
+                        keep_bytes = self._flush_prefix_tail_size(buffer)
+                        emit_bytes = buffer[: len(buffer) - keep_bytes]
+                        buffer = buffer[len(buffer) - keep_bytes :]
+                        if emit_bytes:
+                            self._emit_bytes(emit, exec_id, emit_bytes, finished)
+                        break
+
+                    if len(buffer) < marker_index + marker_size:
+                        if marker_index > 0:
+                            self._emit_bytes(
+                                emit,
+                                exec_id,
+                                buffer[:marker_index],
+                                finished,
+                            )
+                            buffer = buffer[marker_index:]
+                        break
+
+                    if marker_index > 0:
+                        self._emit_bytes(
+                            emit,
+                            exec_id,
+                            buffer[:marker_index],
+                            finished,
+                        )
+
+                    token_start = marker_index + len(self._flush_prefix)
+                    token_end = token_start + self._FLUSH_TOKEN_BYTES
+                    token = buffer[token_start:token_end]
+                    self._ack_flush_marker(token)
+                    buffer = buffer[token_end:]
+        finally:
+            if buffer:
+                self._emit_bytes(emit, exec_id, buffer, finished)
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _emit_bytes(
+        emit: Callable[[str, str], None],
+        exec_id: str,
+        data: bytes,
+        finished: threading.Event,
+    ) -> None:
+        if not data or finished.is_set():
+            return
+        emit(exec_id, data.decode("utf-8", errors="replace"))
+
+    def _close_flush_fds(self) -> None:
+        for fd in (self._stdout_flush_fd, self._stderr_flush_fd):
+            if fd is None:
+                continue
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self._stdout_flush_fd = None
+        self._stderr_flush_fd = None
+
+    @staticmethod
+    def _ensure_fd_open(fd: int, flags: int) -> None:
+        try:
+            os.fstat(fd)
+            return
+        except OSError:
+            pass
+
+        replacement_fd = os.open(os.devnull, flags)
+        try:
+            os.dup2(replacement_fd, fd, inheritable=True)
+            os.set_inheritable(fd, True)
+        finally:
+            if replacement_fd != fd:
+                os.close(replacement_fd)
+
+    @staticmethod
+    def _redirect_fd_to_devnull(fd: int) -> None:
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            os.dup2(devnull_fd, fd, inheritable=True)
+            os.set_inheritable(fd, True)
+        finally:
+            if devnull_fd != fd:
+                os.close(devnull_fd)
+
+    def _flush_prefix_tail_size(self, data: bytes) -> int:
+        max_size = min(len(data), len(self._flush_prefix) - 1)
+        for size in range(max_size, 0, -1):
+            if self._flush_prefix.startswith(data[-size:]):
+                return size
+        return 0
+
+
 class _PyReplWorker:
     """Process-local worker that executes code in a persistent shell."""
 
-    def __init__(self, command_queue: Any, event_queue: Any):
+    def __init__(
+        self,
+        command_queue: Any,
+        event_queue: Any,
+    ):
         self._command_queue = command_queue
         self._event_queue = event_queue
+        self._emit_lock = threading.Lock()
         self._pending_commands: list[dict[str, Any]] = []
         self._active_exec_id: Optional[str] = None
         self._input_idle_timeout_seconds = 300.0
         self._cell_counter = 0
+
+        if hasattr(os, "setsid"):
+            try:
+                os.setsid()
+            except OSError:
+                pass
+
+        self._fd_capture = _FdCapture(
+            emit_stdout=lambda exec_id, text: self._emit_bound_output(
+                EVENT_STDOUT,
+                exec_id,
+                text,
+            ),
+            emit_stderr=lambda exec_id, text: self._emit_bound_output(
+                EVENT_STDERR,
+                exec_id,
+                text,
+            ),
+        )
+        self._fd_capture.install()
 
         self._shell = InteractiveShell()
         self._namespace = self._shell.user_ns
@@ -128,7 +435,11 @@ class _PyReplWorker:
 
     def _emit(self, event_type: str, **payload: Any) -> None:
         message = {"type": event_type, **payload}
-        self._event_queue.put(message)
+        with self._emit_lock:
+            self._event_queue.put(message)
+
+    def _emit_bound_output(self, event_type: str, exec_id: str, text: str) -> None:
+        self._emit(event_type, exec_id=exec_id, text=text)
 
     def _next_command(self, timeout: Optional[float]) -> Optional[dict[str, Any]]:
         if self._pending_commands:
@@ -555,7 +866,6 @@ class _PyReplWorker:
                 else:
                     self._namespace["display"] = old_display
 
-
     def _handle_execute(self, command: dict[str, Any]) -> None:
         exec_id = str(command.get("exec_id", ""))
         code = command.get("code", "")
@@ -636,6 +946,7 @@ class _PyReplWorker:
         builtins.input = input_hook
 
         try:
+            self._fd_capture.begin_execution(exec_id)
             return_value, artifacts = self._execute_python_code(
                 code=code,
                 filename=filename,
@@ -682,6 +993,7 @@ class _PyReplWorker:
                 sys.stderr.flush()
             except Exception:
                 pass
+            self._fd_capture.finish_execution()
 
             sys.stdout = old_stdout
             sys.stderr = old_stderr
@@ -746,7 +1058,10 @@ def run_pyrepl_worker(
             )
             return
 
-    worker = _PyReplWorker(command_queue=command_queue, event_queue=event_queue)
+    worker = _PyReplWorker(
+        command_queue=command_queue,
+        event_queue=event_queue,
+    )
     worker.run_forever()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SimpleLLMFunc"
-version = "0.8.3"
+version = "0.8.4"
 description = "A lightweight yet complete LLM/Agent application development framework. Provides decorators that use function docstrings as prompts, requiring no function body implementation while allowing you to benefit from function definitions and type annotations for higher development efficiency. Seamlessly integrate LLM capabilities into any Python project with minimal code."
 authors = ["Ni Jingzhe <nijingzhe@zju.edu.cn>"]
 readme = "README.md"

--- a/skills/simplellmfunc-developer/SKILL.md
+++ b/skills/simplellmfunc-developer/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Python 3.12+ repo with pytest, Poetry, Mintlify docs, and SimpleLLMFunc source tree available."
 metadata:
   project: SimpleLLMFunc
-  version: "0.8.3"
+  version: "0.8.4"
 ---
 
 # SimpleLLMFunc Framework Development

--- a/skills/simplellmfunc-developer/reference/pyrepl-architecture.md
+++ b/skills/simplellmfunc-developer/reference/pyrepl-architecture.md
@@ -32,7 +32,7 @@ Important boundaries:
 - `SimpleLLMFunc/builtin/pyrepl_worker_client.py`: subprocess and multiprocessing queue lifecycle.
 - `SimpleLLMFunc/builtin/pyrepl_worker_mixin.py`: facade-compatible wrappers around the worker client.
 - `SimpleLLMFunc/builtin/pyrepl_execution.py`: main-process `execute()` / `reset()` orchestration, timeout handling, event polling, event-emitter forwarding, audit payload assembly.
-- `SimpleLLMFunc/builtin/pyrepl_worker.py`: worker-process IPython shell, stdout/stderr capture, `input()` hook, primitive RPC transport, image artifact capture.
+- `SimpleLLMFunc/builtin/pyrepl_worker.py`: worker-process IPython shell, fd-level and Python-level stdout/stderr capture, `input()` hook, primitive RPC transport, image artifact capture.
 - `SimpleLLMFunc/builtin/pyrepl_primitive_host.py`: main-process primitive registry/backend host and primitive call execution.
 - `SimpleLLMFunc/builtin/pyrepl_tools.py`: `execute_code` / `reset_repl` tool definitions, output formatting, and artifact-to-multimodal return conversion.
 - `SimpleLLMFunc/runtime/worker_proxy.py`: worker-side dynamic `runtime` proxy and dotted namespace builder.
@@ -46,7 +46,7 @@ Startup sequence:
 
 1. Create `command_queue` and `event_queue`.
 2. Spawn a daemon worker process targeting `run_pyrepl_worker(command_queue, event_queue, working_directory)`.
-3. Worker constructs `_PyReplWorker`, then emits `EVENT_WORKER_READY`.
+3. Worker constructs `_PyReplWorker`, isolates fd 0/1/2, detaches from the controlling terminal on POSIX when possible, then emits `EVENT_WORKER_READY`.
 4. Main process waits up to 10 seconds for `EVENT_WORKER_READY`, while preserving unexpected startup events in `prefetched_events`.
 
 Main-to-worker command messages are plain dicts:
@@ -92,7 +92,13 @@ This preserves normal REPL state across calls: variables defined in one `execute
 
 ## stdout and stderr capture
 
-stdout/stderr capture happens inside the worker process.
+stdout/stderr capture happens inside the worker process. It has two layers:
+
+- fd-level capture redirects worker fd `0` to `/dev/null`. During each execution, fd `1`/`2` point to execution-scoped worker-owned pipes. Reader threads drain those pipes and emit `EVENT_STDOUT` / `EVENT_STDERR` with that execution's `exec_id`. This captures `os.write(...)`, C extension writes, shell commands, and subprocess stdout/stderr.
+- Between executions, worker fd `1`/`2` point to `/dev/null`. Long-lived children keep their old execution pipe; late output is drained and dropped instead of contaminating later snippets or reaching the host terminal.
+- Python-level capture replaces `sys.stdout` / `sys.stderr` during each execution so normal Python `print()` output still streams line-by-line and is not duplicated by fd capture.
+
+On POSIX, worker startup also calls `os.setsid()` when possible before user code runs. This prevents the worker and descendants from keeping the host terminal as their controlling terminal.
 
 Before executing user code, `_handle_execute(...)` temporarily replaces:
 
@@ -118,8 +124,8 @@ The main process receives these events in `PyReplExecutionMixin.execute(...)`, a
 There are two output paths:
 
 ```text
-worker stdout capture -> event_queue -> stdout_parts -> final execute result / tool summary
-worker stdout capture -> event_queue -> ToolEventEmitter -> ReAct CustomEvent stream
+worker output capture -> event_queue -> stdout_parts/stderr_parts -> final execute result / tool summary
+worker output capture -> event_queue -> ToolEventEmitter -> ReAct CustomEvent stream
 ```
 
 ## ToolEventEmitter path

--- a/skills/simplellmfunc/SKILL.md
+++ b/skills/simplellmfunc/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Python 3.12+ repo with async execution and OpenAI-compatible chat endpoints or OpenAI Responses API endpoints configured through provider.json."
 metadata:
   project: SimpleLLMFunc
-  version: "0.8.3"
+  version: "0.8.4"
 ---
 
 # SimpleLLMFunc Usage

--- a/skills/simplellmfunc/reference/docs-source/pyrepl.md
+++ b/skills/simplellmfunc/reference/docs-source/pyrepl.md
@@ -6,7 +6,7 @@ SimpleLLMFunc 提供内置的 PyRepl 支持，允许 LLM 在一个连续上下�
 
 - **IPython 子进程后端**：每个 `PyRepl` 实例对应一个独立子进程，内部运行 `IPython InteractiveShell`
 - **连续上下文**：变量在多次调用间持久化，LLM 可以分步执行任务
-- **实时流式输出**：通过 `event_emitter` 实时获取 stdout/stderr 输出
+- **实时流式输出**：通过 `event_emitter` 实时获取 stdout/stderr 输出，包括 Python `print()`、直接 fd 写入和子进程 stdout/stderr
 - **图片产物返回**：`display(Image(...))` 或最后表达式产生的图片会被捕获为多模态工具返回
 - **异步不阻塞**：代码执行在独立线程运行，不阻塞主事件循环（适合 TUI/流式 UI）
 - **Session 隔离**：不同的 PyRepl 实例相互独立，互不影响
@@ -15,6 +15,7 @@ SimpleLLMFunc 提供内置的 PyRepl 支持，允许 LLM 在一个连续上下�
 - **长输出自动截断**：`execute_code` 已启用 `too_long_to_file`，当输出超过 20000 tokens 时自动保存到临时文件并截断返回
 - **Runtime 原语**：通过 `runtime.selfref.context.*` 与 `runtime.selfref.fork.*` 暴露受控的 self-reference API
 - **Origin 感知事件流**：每个 `EventYield` 都携带 `origin` 元数据，方便在 TUI 或自定义 UI 中稳定区分主链路和 fork 链路
+- **终端隔离**：PyRepl worker 默认不继承宿主终端的 fd 0/1/2，并在 POSIX 上尽量脱离控制终端，避免子进程污染 TUI/daemon 宿主的终端状态
 
 ## 快速开始
 

--- a/skills/simplellmfunc/reference/pyrepl-runtime.md
+++ b/skills/simplellmfunc/reference/pyrepl-runtime.md
@@ -65,6 +65,7 @@ Important fork context rules:
 - Print checkpoints and short summaries instead of dumping huge objects.
 - Prefer runtime discovery before assuming a primitive contract.
 - Treat REPL state as persistent and cumulative across calls.
+- PyRepl isolates worker stdio by default: child process stdout/stderr and direct fd writes are captured into tool output instead of inheriting the host terminal.
 
 ## Important reset behavior
 

--- a/spec/project-map.md
+++ b/spec/project-map.md
@@ -251,7 +251,7 @@ SimpleLLMFunc/
 - `pyrepl_audit.py`: audit log
 - `pyrepl_input_bridge.py`: process-wide input() request/reply bridge
 - `pyrepl_input_mixin.py`: PyRepl input submission API
-- `pyrepl_worker.py`: PyRepl 子进程 worker
+- `pyrepl_worker.py`: PyRepl 子进程 worker，负责 fd/stdout/stderr 捕获、执行命名空间与 runtime 代理
 - `file_tools.py`: workspace-scoped 文件工具，带 stale-write protection
 
 ### hooks 模块

--- a/tests/test_builtin/test_pyrepl.py
+++ b/tests/test_builtin/test_pyrepl.py
@@ -630,6 +630,114 @@ display(Image(data=b'fake image data', format='png'), "keep text")
         assert result["success"] is True
         assert "ok" in result["stdout"]
 
+    @pytest.mark.asyncio
+    async def test_execute_worker_standard_fds_are_isolated(self):
+        """Worker fd 0/1/2 should not inherit a host tty by default."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        repl = PyRepl()
+        try:
+            result = await repl.execute(
+                "import os\n"
+                "for fd in (0, 1, 2):\n"
+                "    print(f'{fd}:{os.isatty(fd)}')"
+            )
+        finally:
+            repl.close()
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        assert result["stdout"].splitlines() == ["0:False", "1:False", "2:False"]
+
+    @pytest.mark.asyncio
+    async def test_execute_captures_direct_fd_writes(self):
+        """Direct os.write output should be captured into execute results."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        repl = PyRepl()
+        try:
+            result = await repl.execute(
+                "import os\n"
+                "os.write(1, b'DIRECT_FD1_MARKER\\n')\n"
+                "os.write(2, b'DIRECT_FD2_MARKER\\n')"
+            )
+        finally:
+            repl.close()
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        assert "DIRECT_FD1_MARKER" in result["stdout"]
+        assert "DIRECT_FD2_MARKER" in result["stderr"]
+
+    @pytest.mark.asyncio
+    async def test_execute_captures_child_process_fd_writes(self):
+        """Subprocess fd output should use the PyRepl output channel."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        child_code = (
+            "import os; "
+            "os.write(1, b'CHILD_FD1_MARKER\\n'); "
+            "os.write(2, b'CHILD_FD2_MARKER\\n')"
+        )
+        repl = PyRepl()
+        try:
+            result = await repl.execute(
+                "import subprocess, sys\n"
+                f"subprocess.run([sys.executable, '-c', {child_code!r}], check=False)"
+            )
+        finally:
+            repl.close()
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        assert "CHILD_FD1_MARKER" in result["stdout"]
+        assert "CHILD_FD2_MARKER" in result["stderr"]
+
+    @pytest.mark.asyncio
+    async def test_late_child_fd_output_does_not_contaminate_next_execute(self):
+        """Long-lived child output should not be attributed to later snippets."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        child_code = (
+            "import os, time; "
+            "time.sleep(0.15); "
+            "os.write(1, b'LATE_CHILD_FD_MARKER\\n')"
+        )
+        repl = PyRepl()
+        try:
+            spawn_result = await repl.execute(
+                "import subprocess, sys\n"
+                f"subprocess.Popen([sys.executable, '-c', {child_code!r}])\n"
+                "print('child spawned')"
+            )
+            next_result = await repl.execute(
+                "import time\n"
+                "print('NEXT_EXECUTE_START')\n"
+                "time.sleep(0.4)\n"
+                "print('NEXT_EXECUTE_END')"
+            )
+        finally:
+            repl.close()
+
+        assert spawn_result["success"] is True, spawn_result["error"] or spawn_result["stderr"]
+        assert next_result["success"] is True, next_result["error"] or next_result["stderr"]
+        assert "LATE_CHILD_FD_MARKER" not in next_result["stdout"]
+        assert next_result["stdout"].splitlines() == [
+            "NEXT_EXECUTE_START",
+            "NEXT_EXECUTE_END",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_execute_python_print_is_not_duplicated_by_fd_capture(self):
+        """Python print output should still be emitted once via _LineCapture."""
+        from SimpleLLMFunc.builtin import PyRepl
+
+        repl = PyRepl()
+        try:
+            result = await repl.execute("print('PRINT_MARKER')")
+        finally:
+            repl.close()
+
+        assert result["success"] is True, result["error"] or result["stderr"]
+        assert result["stdout"].splitlines().count("PRINT_MARKER") == 1
+
 
 class TestPyReplAudit:
     """Test per-instance audit log persistence behavior."""
@@ -1801,6 +1909,9 @@ class TestPyReplEventLoopSafety:
         from SimpleLLMFunc.builtin import PyRepl
 
         repl = PyRepl()
+        warmup = await repl.execute("0")
+        assert warmup["success"] is True, warmup["error"] or warmup["stderr"]
+
         tick_count = 0
         running = True
 

--- a/tests/test_interface/test_openai_compatible.py
+++ b/tests/test_interface/test_openai_compatible.py
@@ -140,7 +140,7 @@ async def test_chat_stream_stops_after_finish_reason() -> None:
             chunks.append(chunk)
         return chunks
 
-    chunks = await asyncio.wait_for(_collect_chunks(), timeout=0.2)
+    chunks = await asyncio.wait_for(_collect_chunks(), timeout=1.0)
 
     assert len(chunks) == 2
     assert chunks[-1].choices[0].finish_reason == "stop"
@@ -191,7 +191,7 @@ async def test_chat_stream_keeps_post_finish_usage_chunk() -> None:
             chunks.append(chunk)
         return chunks
 
-    chunks = await asyncio.wait_for(_collect_chunks(), timeout=0.3)
+    chunks = await asyncio.wait_for(_collect_chunks(), timeout=1.0)
 
     assert len(chunks) == 3
     assert chunks[1].choices[0].finish_reason == "stop"
@@ -240,7 +240,7 @@ async def test_chat_stream_allows_non_usage_chunk_before_usage() -> None:
             chunks.append(chunk)
         return chunks
 
-    chunks = await asyncio.wait_for(_collect_chunks(), timeout=0.3)
+    chunks = await asyncio.wait_for(_collect_chunks(), timeout=1.0)
 
     assert len(chunks) == 4
     assert chunks[-1].usage is not None
@@ -291,7 +291,7 @@ async def test_chat_stream_fallback_without_stream_options() -> None:
             chunks.append(chunk)
         return chunks
 
-    chunks = await asyncio.wait_for(_collect_chunks(), timeout=0.3)
+    chunks = await asyncio.wait_for(_collect_chunks(), timeout=1.0)
 
     assert len(chunks) == 2
     assert create_mock.await_count == 2


### PR DESCRIPTION
## Summary
- isolate PyRepl worker fd 0/1/2 from host terminals and capture direct fd/subprocess output
- drop late child-process output so it cannot contaminate later execute_code calls
- bump release metadata to 0.8.4 and update README, changelog, specs, and bundled skills
- stabilize timing-sensitive async tests exposed by full-suite release runs

## Validation
- poetry run pytest (678 passed)
- poetry run ruff check SimpleLLMFunc/builtin/pyrepl_worker.py tests/test_builtin/test_pyrepl.py tests/test_interface/test_openai_compatible.py
- poetry check
- poetry build
- poetry publish --dry-run
- git diff --check